### PR TITLE
Move random/replacement/repeat/column/context_columns params to column schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,6 @@ Common fields:
 
 - **name**: The name of the source (e.g., `"cuisines"`).
 - **type**: The type of the source, which can be `"ai"`, `"list"`, or `"linked"`.
-- **random**: When set to `true`, each row generation will pick a random value from all available values in the source.
-- **replacement**: Defines whether the sampling is with or without replacement. When set to `true`, items can be selected multiple times; when set to `false`, once an item is selected, it cannot be chosen again.
-- **repeat**: The number of times the picked value is reused before switching to the next one. The default and minimum value is 1, meaning each value is used once.
 
 Special fields for different types:
 
@@ -298,3 +295,18 @@ A list of column definitions. Each column is an object that can contain the foll
 	- `"pick"`: Values are picked from an existing source (e.g., a list of cuisines).
 - **context_length** (Optional): Defines how many previous values in this column will be sent to the LLM when generating a new row. This helps provide context for the generation.
 - **source** (Optional): Specifies the source to pull data from when `fill_mode` is set to `"pick"`. This should match a source name defined in the `sources` section (e.g., `"cuisines"`).
+
+**Additional Fields for `pick` Mode**
+
+When `fill_mode` is set to `"pick"`, the following fields are available:
+
+- **random**: If `true`, a random value is selected for each row from all available options in the source. Default: `false`.
+- **replacement**: Determines whether sampling is with or without replacement:
+  - `true`: Items can be selected multiple times.
+  - `false`: Once an item is selected, it cannot be chosen again.
+  - Default: `false`.
+- **repeat**: Specifies how many times a picked value is reused before switching to the next one. The minimum and default value is `1`, meaning each value is used once before moving to the next.
+
+**Shared Source Behavior**
+
+If multiple columns use the same source but have different `random`, `replacement`, or `repeat` settings, the source is initialized only once. For example, if a `"tags"` source generates 20 tag options via AI and three columns reference it, the tag generation process runs once, and all three columns share the same selection pool.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pre-built binaries for different operating systems are available on the [Release
 Ensure that Go is installed on your system. Then run `go install github.com/Yiling-J/tablepilot@latest`. Only CLI/API are supported.
 
 #### Install from Source
-Ensure that Go is installed on your system. Then, clone the repository and run `make install`. After installation, the `tablepilot` command should be available for use.  This includes CLI, API, and WebUI. However, to use the WebUI, you need to build the frontend first. Ensure you have `pnpm` and `node` installed, then run `make build-ui`, Once built, you can start the server using `serve` command.
+Ensure that Go is installed on your system. Then, clone the repository and run `make install`. After installation, the `tablepilot` command should be available for use.  This includes CLI, API, and WebUI. However, to use the WebUI, you need to build the frontend first. Ensure you have `pnpm`, `tsc` and `node` installed, then run `make build-ui`, Once built, you can start the server using `serve` command.
 
 ## How to Use
 

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -23,6 +23,8 @@ var (
 		{Name: "random", Type: field.TypeBool, Default: false},
 		{Name: "replacement", Type: field.TypeBool, Default: false},
 		{Name: "repeat", Type: field.TypeInt, Default: 1},
+		{Name: "linked_column", Type: field.TypeString, Default: ""},
+		{Name: "linked_context_columns", Type: field.TypeJSON},
 		{Name: "table_id", Type: field.TypeInt},
 	}
 	// TableColumnsTable holds the schema information for the "table_columns" table.
@@ -33,7 +35,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "table_columns_table_meta_columns",
-				Columns:    []*schema.Column{TableColumnsColumns[13]},
+				Columns:    []*schema.Column{TableColumnsColumns[15]},
 				RefColumns: []*schema.Column{TableMetaColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -42,7 +44,7 @@ var (
 			{
 				Name:    "tablecolumn_name_table_id",
 				Unique:  true,
-				Columns: []*schema.Column{TableColumnsColumns[4], TableColumnsColumns[13]},
+				Columns: []*schema.Column{TableColumnsColumns[4], TableColumnsColumns[15]},
 			},
 		},
 	}

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -18,8 +18,11 @@ var (
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"string", "number", "integer", "boolean", "array"}},
 		{Name: "fill_mode", Type: field.TypeEnum, Enums: []string{"ai", "pick"}},
-		{Name: "source", Type: field.TypeJSON, Nullable: true},
+		{Name: "source", Type: field.TypeString, Nullable: true},
 		{Name: "context_length", Type: field.TypeInt, Default: 0},
+		{Name: "random", Type: field.TypeBool, Default: false},
+		{Name: "replacement", Type: field.TypeBool, Default: false},
+		{Name: "repeat", Type: field.TypeInt, Default: 1},
 		{Name: "table_id", Type: field.TypeInt},
 	}
 	// TableColumnsTable holds the schema information for the "table_columns" table.
@@ -30,7 +33,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "table_columns_table_meta_columns",
-				Columns:    []*schema.Column{TableColumnsColumns[10]},
+				Columns:    []*schema.Column{TableColumnsColumns[13]},
 				RefColumns: []*schema.Column{TableMetaColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -39,7 +42,7 @@ var (
 			{
 				Name:    "tablecolumn_name_table_id",
 				Unique:  true,
-				Columns: []*schema.Column{TableColumnsColumns[4], TableColumnsColumns[10]},
+				Columns: []*schema.Column{TableColumnsColumns[4], TableColumnsColumns[13]},
 			},
 		},
 	}
@@ -52,6 +55,7 @@ var (
 		{Name: "name", Type: field.TypeString, Unique: true},
 		{Name: "description", Type: field.TypeString, Default: ""},
 		{Name: "model", Type: field.TypeString, Default: ""},
+		{Name: "sources", Type: field.TypeJSON, Nullable: true},
 	}
 	// TableMetaTable holds the schema information for the "table_meta" table.
 	TableMetaTable = &schema.Table{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -36,29 +36,32 @@ const (
 // TableColumnMutation represents an operation that mutates the TableColumn nodes in the graph.
 type TableColumnMutation struct {
 	config
-	op                Op
-	typ               string
-	id                *int
-	created_at        *time.Time
-	updated_at        *time.Time
-	nanoid            *string
-	name              *string
-	description       *string
-	_type             *tablecolumn.Type
-	fill_mode         *tablecolumn.FillMode
-	source            *string
-	context_length    *int
-	addcontext_length *int
-	random            *bool
-	replacement       *bool
-	repeat            *int
-	addrepeat         *int
-	clearedFields     map[string]struct{}
-	tablemeta         *int
-	clearedtablemeta  bool
-	done              bool
-	oldValue          func(context.Context) (*TableColumn, error)
-	predicates        []predicate.TableColumn
+	op                           Op
+	typ                          string
+	id                           *int
+	created_at                   *time.Time
+	updated_at                   *time.Time
+	nanoid                       *string
+	name                         *string
+	description                  *string
+	_type                        *tablecolumn.Type
+	fill_mode                    *tablecolumn.FillMode
+	source                       *string
+	context_length               *int
+	addcontext_length            *int
+	random                       *bool
+	replacement                  *bool
+	repeat                       *int
+	addrepeat                    *int
+	linked_column                *string
+	linked_context_columns       *[]string
+	appendlinked_context_columns []string
+	clearedFields                map[string]struct{}
+	tablemeta                    *int
+	clearedtablemeta             bool
+	done                         bool
+	oldValue                     func(context.Context) (*TableColumn, error)
+	predicates                   []predicate.TableColumn
 }
 
 var _ ent.Mutation = (*TableColumnMutation)(nil)
@@ -732,6 +735,93 @@ func (m *TableColumnMutation) ResetRepeat() {
 	m.addrepeat = nil
 }
 
+// SetLinkedColumn sets the "linked_column" field.
+func (m *TableColumnMutation) SetLinkedColumn(s string) {
+	m.linked_column = &s
+}
+
+// LinkedColumn returns the value of the "linked_column" field in the mutation.
+func (m *TableColumnMutation) LinkedColumn() (r string, exists bool) {
+	v := m.linked_column
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLinkedColumn returns the old "linked_column" field's value of the TableColumn entity.
+// If the TableColumn object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TableColumnMutation) OldLinkedColumn(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLinkedColumn is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLinkedColumn requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLinkedColumn: %w", err)
+	}
+	return oldValue.LinkedColumn, nil
+}
+
+// ResetLinkedColumn resets all changes to the "linked_column" field.
+func (m *TableColumnMutation) ResetLinkedColumn() {
+	m.linked_column = nil
+}
+
+// SetLinkedContextColumns sets the "linked_context_columns" field.
+func (m *TableColumnMutation) SetLinkedContextColumns(s []string) {
+	m.linked_context_columns = &s
+	m.appendlinked_context_columns = nil
+}
+
+// LinkedContextColumns returns the value of the "linked_context_columns" field in the mutation.
+func (m *TableColumnMutation) LinkedContextColumns() (r []string, exists bool) {
+	v := m.linked_context_columns
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLinkedContextColumns returns the old "linked_context_columns" field's value of the TableColumn entity.
+// If the TableColumn object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TableColumnMutation) OldLinkedContextColumns(ctx context.Context) (v []string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLinkedContextColumns is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLinkedContextColumns requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLinkedContextColumns: %w", err)
+	}
+	return oldValue.LinkedContextColumns, nil
+}
+
+// AppendLinkedContextColumns adds s to the "linked_context_columns" field.
+func (m *TableColumnMutation) AppendLinkedContextColumns(s []string) {
+	m.appendlinked_context_columns = append(m.appendlinked_context_columns, s...)
+}
+
+// AppendedLinkedContextColumns returns the list of values that were appended to the "linked_context_columns" field in this mutation.
+func (m *TableColumnMutation) AppendedLinkedContextColumns() ([]string, bool) {
+	if len(m.appendlinked_context_columns) == 0 {
+		return nil, false
+	}
+	return m.appendlinked_context_columns, true
+}
+
+// ResetLinkedContextColumns resets all changes to the "linked_context_columns" field.
+func (m *TableColumnMutation) ResetLinkedContextColumns() {
+	m.linked_context_columns = nil
+	m.appendlinked_context_columns = nil
+}
+
 // SetTablemetaID sets the "tablemeta" edge to the TableMeta entity by id.
 func (m *TableColumnMutation) SetTablemetaID(id int) {
 	m.tablemeta = &id
@@ -806,7 +896,7 @@ func (m *TableColumnMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TableColumnMutation) Fields() []string {
-	fields := make([]string, 0, 13)
+	fields := make([]string, 0, 15)
 	if m.created_at != nil {
 		fields = append(fields, tablecolumn.FieldCreatedAt)
 	}
@@ -846,6 +936,12 @@ func (m *TableColumnMutation) Fields() []string {
 	if m.repeat != nil {
 		fields = append(fields, tablecolumn.FieldRepeat)
 	}
+	if m.linked_column != nil {
+		fields = append(fields, tablecolumn.FieldLinkedColumn)
+	}
+	if m.linked_context_columns != nil {
+		fields = append(fields, tablecolumn.FieldLinkedContextColumns)
+	}
 	return fields
 }
 
@@ -880,6 +976,10 @@ func (m *TableColumnMutation) Field(name string) (ent.Value, bool) {
 		return m.Replacement()
 	case tablecolumn.FieldRepeat:
 		return m.Repeat()
+	case tablecolumn.FieldLinkedColumn:
+		return m.LinkedColumn()
+	case tablecolumn.FieldLinkedContextColumns:
+		return m.LinkedContextColumns()
 	}
 	return nil, false
 }
@@ -915,6 +1015,10 @@ func (m *TableColumnMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldReplacement(ctx)
 	case tablecolumn.FieldRepeat:
 		return m.OldRepeat(ctx)
+	case tablecolumn.FieldLinkedColumn:
+		return m.OldLinkedColumn(ctx)
+	case tablecolumn.FieldLinkedContextColumns:
+		return m.OldLinkedContextColumns(ctx)
 	}
 	return nil, fmt.Errorf("unknown TableColumn field %s", name)
 }
@@ -1014,6 +1118,20 @@ func (m *TableColumnMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetRepeat(v)
+		return nil
+	case tablecolumn.FieldLinkedColumn:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLinkedColumn(v)
+		return nil
+	case tablecolumn.FieldLinkedContextColumns:
+		v, ok := value.([]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLinkedContextColumns(v)
 		return nil
 	}
 	return fmt.Errorf("unknown TableColumn field %s", name)
@@ -1162,6 +1280,12 @@ func (m *TableColumnMutation) ResetField(name string) error {
 		return nil
 	case tablecolumn.FieldRepeat:
 		m.ResetRepeat()
+		return nil
+	case tablecolumn.FieldLinkedColumn:
+		m.ResetLinkedColumn()
+		return nil
+	case tablecolumn.FieldLinkedContextColumns:
+		m.ResetLinkedContextColumns()
 		return nil
 	}
 	return fmt.Errorf("unknown TableColumn field %s", name)

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -46,10 +46,13 @@ type TableColumnMutation struct {
 	description       *string
 	_type             *tablecolumn.Type
 	fill_mode         *tablecolumn.FillMode
-	source            *json.RawMessage
-	appendsource      json.RawMessage
+	source            *string
 	context_length    *int
 	addcontext_length *int
+	random            *bool
+	replacement       *bool
+	repeat            *int
+	addrepeat         *int
 	clearedFields     map[string]struct{}
 	tablemeta         *int
 	clearedtablemeta  bool
@@ -461,13 +464,12 @@ func (m *TableColumnMutation) ResetFillMode() {
 }
 
 // SetSource sets the "source" field.
-func (m *TableColumnMutation) SetSource(jm json.RawMessage) {
-	m.source = &jm
-	m.appendsource = nil
+func (m *TableColumnMutation) SetSource(s string) {
+	m.source = &s
 }
 
 // Source returns the value of the "source" field in the mutation.
-func (m *TableColumnMutation) Source() (r json.RawMessage, exists bool) {
+func (m *TableColumnMutation) Source() (r string, exists bool) {
 	v := m.source
 	if v == nil {
 		return
@@ -478,7 +480,7 @@ func (m *TableColumnMutation) Source() (r json.RawMessage, exists bool) {
 // OldSource returns the old "source" field's value of the TableColumn entity.
 // If the TableColumn object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *TableColumnMutation) OldSource(ctx context.Context) (v json.RawMessage, err error) {
+func (m *TableColumnMutation) OldSource(ctx context.Context) (v string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldSource is only allowed on UpdateOne operations")
 	}
@@ -492,23 +494,9 @@ func (m *TableColumnMutation) OldSource(ctx context.Context) (v json.RawMessage,
 	return oldValue.Source, nil
 }
 
-// AppendSource adds jm to the "source" field.
-func (m *TableColumnMutation) AppendSource(jm json.RawMessage) {
-	m.appendsource = append(m.appendsource, jm...)
-}
-
-// AppendedSource returns the list of values that were appended to the "source" field in this mutation.
-func (m *TableColumnMutation) AppendedSource() (json.RawMessage, bool) {
-	if len(m.appendsource) == 0 {
-		return nil, false
-	}
-	return m.appendsource, true
-}
-
 // ClearSource clears the value of the "source" field.
 func (m *TableColumnMutation) ClearSource() {
 	m.source = nil
-	m.appendsource = nil
 	m.clearedFields[tablecolumn.FieldSource] = struct{}{}
 }
 
@@ -521,7 +509,6 @@ func (m *TableColumnMutation) SourceCleared() bool {
 // ResetSource resets all changes to the "source" field.
 func (m *TableColumnMutation) ResetSource() {
 	m.source = nil
-	m.appendsource = nil
 	delete(m.clearedFields, tablecolumn.FieldSource)
 }
 
@@ -617,6 +604,134 @@ func (m *TableColumnMutation) ResetTableID() {
 	m.tablemeta = nil
 }
 
+// SetRandom sets the "random" field.
+func (m *TableColumnMutation) SetRandom(b bool) {
+	m.random = &b
+}
+
+// Random returns the value of the "random" field in the mutation.
+func (m *TableColumnMutation) Random() (r bool, exists bool) {
+	v := m.random
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRandom returns the old "random" field's value of the TableColumn entity.
+// If the TableColumn object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TableColumnMutation) OldRandom(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRandom is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRandom requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRandom: %w", err)
+	}
+	return oldValue.Random, nil
+}
+
+// ResetRandom resets all changes to the "random" field.
+func (m *TableColumnMutation) ResetRandom() {
+	m.random = nil
+}
+
+// SetReplacement sets the "replacement" field.
+func (m *TableColumnMutation) SetReplacement(b bool) {
+	m.replacement = &b
+}
+
+// Replacement returns the value of the "replacement" field in the mutation.
+func (m *TableColumnMutation) Replacement() (r bool, exists bool) {
+	v := m.replacement
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldReplacement returns the old "replacement" field's value of the TableColumn entity.
+// If the TableColumn object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TableColumnMutation) OldReplacement(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldReplacement is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldReplacement requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldReplacement: %w", err)
+	}
+	return oldValue.Replacement, nil
+}
+
+// ResetReplacement resets all changes to the "replacement" field.
+func (m *TableColumnMutation) ResetReplacement() {
+	m.replacement = nil
+}
+
+// SetRepeat sets the "repeat" field.
+func (m *TableColumnMutation) SetRepeat(i int) {
+	m.repeat = &i
+	m.addrepeat = nil
+}
+
+// Repeat returns the value of the "repeat" field in the mutation.
+func (m *TableColumnMutation) Repeat() (r int, exists bool) {
+	v := m.repeat
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRepeat returns the old "repeat" field's value of the TableColumn entity.
+// If the TableColumn object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TableColumnMutation) OldRepeat(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRepeat is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRepeat requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRepeat: %w", err)
+	}
+	return oldValue.Repeat, nil
+}
+
+// AddRepeat adds i to the "repeat" field.
+func (m *TableColumnMutation) AddRepeat(i int) {
+	if m.addrepeat != nil {
+		*m.addrepeat += i
+	} else {
+		m.addrepeat = &i
+	}
+}
+
+// AddedRepeat returns the value that was added to the "repeat" field in this mutation.
+func (m *TableColumnMutation) AddedRepeat() (r int, exists bool) {
+	v := m.addrepeat
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetRepeat resets all changes to the "repeat" field.
+func (m *TableColumnMutation) ResetRepeat() {
+	m.repeat = nil
+	m.addrepeat = nil
+}
+
 // SetTablemetaID sets the "tablemeta" edge to the TableMeta entity by id.
 func (m *TableColumnMutation) SetTablemetaID(id int) {
 	m.tablemeta = &id
@@ -691,7 +806,7 @@ func (m *TableColumnMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TableColumnMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 13)
 	if m.created_at != nil {
 		fields = append(fields, tablecolumn.FieldCreatedAt)
 	}
@@ -722,6 +837,15 @@ func (m *TableColumnMutation) Fields() []string {
 	if m.tablemeta != nil {
 		fields = append(fields, tablecolumn.FieldTableID)
 	}
+	if m.random != nil {
+		fields = append(fields, tablecolumn.FieldRandom)
+	}
+	if m.replacement != nil {
+		fields = append(fields, tablecolumn.FieldReplacement)
+	}
+	if m.repeat != nil {
+		fields = append(fields, tablecolumn.FieldRepeat)
+	}
 	return fields
 }
 
@@ -750,6 +874,12 @@ func (m *TableColumnMutation) Field(name string) (ent.Value, bool) {
 		return m.ContextLength()
 	case tablecolumn.FieldTableID:
 		return m.TableID()
+	case tablecolumn.FieldRandom:
+		return m.Random()
+	case tablecolumn.FieldReplacement:
+		return m.Replacement()
+	case tablecolumn.FieldRepeat:
+		return m.Repeat()
 	}
 	return nil, false
 }
@@ -779,6 +909,12 @@ func (m *TableColumnMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldContextLength(ctx)
 	case tablecolumn.FieldTableID:
 		return m.OldTableID(ctx)
+	case tablecolumn.FieldRandom:
+		return m.OldRandom(ctx)
+	case tablecolumn.FieldReplacement:
+		return m.OldReplacement(ctx)
+	case tablecolumn.FieldRepeat:
+		return m.OldRepeat(ctx)
 	}
 	return nil, fmt.Errorf("unknown TableColumn field %s", name)
 }
@@ -838,7 +974,7 @@ func (m *TableColumnMutation) SetField(name string, value ent.Value) error {
 		m.SetFillMode(v)
 		return nil
 	case tablecolumn.FieldSource:
-		v, ok := value.(json.RawMessage)
+		v, ok := value.(string)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -858,6 +994,27 @@ func (m *TableColumnMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetTableID(v)
 		return nil
+	case tablecolumn.FieldRandom:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRandom(v)
+		return nil
+	case tablecolumn.FieldReplacement:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetReplacement(v)
+		return nil
+	case tablecolumn.FieldRepeat:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRepeat(v)
+		return nil
 	}
 	return fmt.Errorf("unknown TableColumn field %s", name)
 }
@@ -869,6 +1026,9 @@ func (m *TableColumnMutation) AddedFields() []string {
 	if m.addcontext_length != nil {
 		fields = append(fields, tablecolumn.FieldContextLength)
 	}
+	if m.addrepeat != nil {
+		fields = append(fields, tablecolumn.FieldRepeat)
+	}
 	return fields
 }
 
@@ -879,6 +1039,8 @@ func (m *TableColumnMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
 	case tablecolumn.FieldContextLength:
 		return m.AddedContextLength()
+	case tablecolumn.FieldRepeat:
+		return m.AddedRepeat()
 	}
 	return nil, false
 }
@@ -894,6 +1056,13 @@ func (m *TableColumnMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddContextLength(v)
+		return nil
+	case tablecolumn.FieldRepeat:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddRepeat(v)
 		return nil
 	}
 	return fmt.Errorf("unknown TableColumn numeric field %s", name)
@@ -985,6 +1154,15 @@ func (m *TableColumnMutation) ResetField(name string) error {
 	case tablecolumn.FieldTableID:
 		m.ResetTableID()
 		return nil
+	case tablecolumn.FieldRandom:
+		m.ResetRandom()
+		return nil
+	case tablecolumn.FieldReplacement:
+		m.ResetReplacement()
+		return nil
+	case tablecolumn.FieldRepeat:
+		m.ResetRepeat()
+		return nil
 	}
 	return fmt.Errorf("unknown TableColumn field %s", name)
 }
@@ -1075,6 +1253,7 @@ type TableMetaMutation struct {
 	name           *string
 	description    *string
 	model          *string
+	sources        *map[string]json.RawMessage
 	clearedFields  map[string]struct{}
 	columns        map[int]struct{}
 	removedcolumns map[int]struct{}
@@ -1440,6 +1619,55 @@ func (m *TableMetaMutation) ResetModel() {
 	m.model = nil
 }
 
+// SetSources sets the "sources" field.
+func (m *TableMetaMutation) SetSources(mm map[string]json.RawMessage) {
+	m.sources = &mm
+}
+
+// Sources returns the value of the "sources" field in the mutation.
+func (m *TableMetaMutation) Sources() (r map[string]json.RawMessage, exists bool) {
+	v := m.sources
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSources returns the old "sources" field's value of the TableMeta entity.
+// If the TableMeta object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TableMetaMutation) OldSources(ctx context.Context) (v map[string]json.RawMessage, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSources is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSources requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSources: %w", err)
+	}
+	return oldValue.Sources, nil
+}
+
+// ClearSources clears the value of the "sources" field.
+func (m *TableMetaMutation) ClearSources() {
+	m.sources = nil
+	m.clearedFields[tablemeta.FieldSources] = struct{}{}
+}
+
+// SourcesCleared returns if the "sources" field was cleared in this mutation.
+func (m *TableMetaMutation) SourcesCleared() bool {
+	_, ok := m.clearedFields[tablemeta.FieldSources]
+	return ok
+}
+
+// ResetSources resets all changes to the "sources" field.
+func (m *TableMetaMutation) ResetSources() {
+	m.sources = nil
+	delete(m.clearedFields, tablemeta.FieldSources)
+}
+
 // AddColumnIDs adds the "columns" edge to the TableColumn entity by ids.
 func (m *TableMetaMutation) AddColumnIDs(ids ...int) {
 	if m.columns == nil {
@@ -1582,7 +1810,7 @@ func (m *TableMetaMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TableMetaMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.created_at != nil {
 		fields = append(fields, tablemeta.FieldCreatedAt)
 	}
@@ -1600,6 +1828,9 @@ func (m *TableMetaMutation) Fields() []string {
 	}
 	if m.model != nil {
 		fields = append(fields, tablemeta.FieldModel)
+	}
+	if m.sources != nil {
+		fields = append(fields, tablemeta.FieldSources)
 	}
 	return fields
 }
@@ -1621,6 +1852,8 @@ func (m *TableMetaMutation) Field(name string) (ent.Value, bool) {
 		return m.Description()
 	case tablemeta.FieldModel:
 		return m.Model()
+	case tablemeta.FieldSources:
+		return m.Sources()
 	}
 	return nil, false
 }
@@ -1642,6 +1875,8 @@ func (m *TableMetaMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldDescription(ctx)
 	case tablemeta.FieldModel:
 		return m.OldModel(ctx)
+	case tablemeta.FieldSources:
+		return m.OldSources(ctx)
 	}
 	return nil, fmt.Errorf("unknown TableMeta field %s", name)
 }
@@ -1693,6 +1928,13 @@ func (m *TableMetaMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetModel(v)
 		return nil
+	case tablemeta.FieldSources:
+		v, ok := value.(map[string]json.RawMessage)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSources(v)
+		return nil
 	}
 	return fmt.Errorf("unknown TableMeta field %s", name)
 }
@@ -1732,6 +1974,9 @@ func (m *TableMetaMutation) ClearedFields() []string {
 	if m.FieldCleared(tablemeta.FieldNanoid) {
 		fields = append(fields, tablemeta.FieldNanoid)
 	}
+	if m.FieldCleared(tablemeta.FieldSources) {
+		fields = append(fields, tablemeta.FieldSources)
+	}
 	return fields
 }
 
@@ -1754,6 +1999,9 @@ func (m *TableMetaMutation) ClearField(name string) error {
 		return nil
 	case tablemeta.FieldNanoid:
 		m.ClearNanoid()
+		return nil
+	case tablemeta.FieldSources:
+		m.ClearSources()
 		return nil
 	}
 	return fmt.Errorf("unknown TableMeta nullable field %s", name)
@@ -1780,6 +2028,9 @@ func (m *TableMetaMutation) ResetField(name string) error {
 		return nil
 	case tablemeta.FieldModel:
 		m.ResetModel()
+		return nil
+	case tablemeta.FieldSources:
+		m.ResetSources()
 		return nil
 	}
 	return fmt.Errorf("unknown TableMeta field %s", name)

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -50,6 +50,14 @@ func init() {
 	tablecolumnDescRepeat := tablecolumnFields[9].Descriptor()
 	// tablecolumn.DefaultRepeat holds the default value on creation for the repeat field.
 	tablecolumn.DefaultRepeat = tablecolumnDescRepeat.Default.(int)
+	// tablecolumnDescLinkedColumn is the schema descriptor for linked_column field.
+	tablecolumnDescLinkedColumn := tablecolumnFields[10].Descriptor()
+	// tablecolumn.DefaultLinkedColumn holds the default value on creation for the linked_column field.
+	tablecolumn.DefaultLinkedColumn = tablecolumnDescLinkedColumn.Default.(string)
+	// tablecolumnDescLinkedContextColumns is the schema descriptor for linked_context_columns field.
+	tablecolumnDescLinkedContextColumns := tablecolumnFields[11].Descriptor()
+	// tablecolumn.DefaultLinkedContextColumns holds the default value on creation for the linked_context_columns field.
+	tablecolumn.DefaultLinkedContextColumns = tablecolumnDescLinkedContextColumns.Default.([]string)
 	tablemetaMixin := schema.TableMeta{}.Mixin()
 	tablemetaMixinFields0 := tablemetaMixin[0].Fields()
 	_ = tablemetaMixinFields0

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -38,6 +38,18 @@ func init() {
 	tablecolumnDescContextLength := tablecolumnFields[5].Descriptor()
 	// tablecolumn.DefaultContextLength holds the default value on creation for the context_length field.
 	tablecolumn.DefaultContextLength = tablecolumnDescContextLength.Default.(int)
+	// tablecolumnDescRandom is the schema descriptor for random field.
+	tablecolumnDescRandom := tablecolumnFields[7].Descriptor()
+	// tablecolumn.DefaultRandom holds the default value on creation for the random field.
+	tablecolumn.DefaultRandom = tablecolumnDescRandom.Default.(bool)
+	// tablecolumnDescReplacement is the schema descriptor for replacement field.
+	tablecolumnDescReplacement := tablecolumnFields[8].Descriptor()
+	// tablecolumn.DefaultReplacement holds the default value on creation for the replacement field.
+	tablecolumn.DefaultReplacement = tablecolumnDescReplacement.Default.(bool)
+	// tablecolumnDescRepeat is the schema descriptor for repeat field.
+	tablecolumnDescRepeat := tablecolumnFields[9].Descriptor()
+	// tablecolumn.DefaultRepeat holds the default value on creation for the repeat field.
+	tablecolumn.DefaultRepeat = tablecolumnDescRepeat.Default.(int)
 	tablemetaMixin := schema.TableMeta{}.Mixin()
 	tablemetaMixinFields0 := tablemetaMixin[0].Fields()
 	_ = tablemetaMixinFields0

--- a/ent/schema/tablecolumn.go
+++ b/ent/schema/tablecolumn.go
@@ -32,6 +32,8 @@ func (TableColumn) Fields() []ent.Field {
 		field.Bool("random").Default(false),
 		field.Bool("replacement").Default(false),
 		field.Int("repeat").Default(1),
+		field.String("linked_column").Default(""),
+		field.Strings("linked_context_columns").Default([]string{}),
 	}
 }
 

--- a/ent/schema/tablecolumn.go
+++ b/ent/schema/tablecolumn.go
@@ -1,8 +1,6 @@
 package schema
 
 import (
-	"encoding/json"
-
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
@@ -28,9 +26,12 @@ func (TableColumn) Fields() []ent.Field {
 		field.String("description").Optional(),
 		field.Enum("type").Values("string", "number", "integer", "boolean", "array"),
 		field.Enum("fill_mode").Values("ai", "pick"),
-		field.JSON("source", json.RawMessage{}).Optional(),
+		field.String("source").Optional(),
 		field.Int("context_length").Default(0),
 		field.Int("table_id"),
+		field.Bool("random").Default(false),
+		field.Bool("replacement").Default(false),
+		field.Int("repeat").Default(1),
 	}
 }
 

--- a/ent/schema/tablemeta.go
+++ b/ent/schema/tablemeta.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"regexp"
 
 	"entgo.io/ent"
@@ -27,6 +28,7 @@ func (TableMeta) Fields() []ent.Field {
 		field.String("name").Unique().NotEmpty().Match(regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")),
 		field.String("description").Default(""),
 		field.String("model").Default(""),
+		field.JSON("sources", map[string]json.RawMessage{}).Optional(),
 	}
 }
 

--- a/ent/tablecolumn.go
+++ b/ent/tablecolumn.go
@@ -3,7 +3,6 @@
 package ent
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -34,11 +33,17 @@ type TableColumn struct {
 	// FillMode holds the value of the "fill_mode" field.
 	FillMode tablecolumn.FillMode `json:"fill_mode,omitempty"`
 	// Source holds the value of the "source" field.
-	Source json.RawMessage `json:"source,omitempty"`
+	Source string `json:"source,omitempty"`
 	// ContextLength holds the value of the "context_length" field.
 	ContextLength int `json:"context_length,omitempty"`
 	// TableID holds the value of the "table_id" field.
 	TableID int `json:"table_id,omitempty"`
+	// Random holds the value of the "random" field.
+	Random bool `json:"random,omitempty"`
+	// Replacement holds the value of the "replacement" field.
+	Replacement bool `json:"replacement,omitempty"`
+	// Repeat holds the value of the "repeat" field.
+	Repeat int `json:"repeat,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the TableColumnQuery when eager-loading is set.
 	Edges        TableColumnEdges `json:"edges"`
@@ -70,11 +75,11 @@ func (*TableColumn) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case tablecolumn.FieldSource:
-			values[i] = new([]byte)
-		case tablecolumn.FieldID, tablecolumn.FieldContextLength, tablecolumn.FieldTableID:
+		case tablecolumn.FieldRandom, tablecolumn.FieldReplacement:
+			values[i] = new(sql.NullBool)
+		case tablecolumn.FieldID, tablecolumn.FieldContextLength, tablecolumn.FieldTableID, tablecolumn.FieldRepeat:
 			values[i] = new(sql.NullInt64)
-		case tablecolumn.FieldNanoid, tablecolumn.FieldName, tablecolumn.FieldDescription, tablecolumn.FieldType, tablecolumn.FieldFillMode:
+		case tablecolumn.FieldNanoid, tablecolumn.FieldName, tablecolumn.FieldDescription, tablecolumn.FieldType, tablecolumn.FieldFillMode, tablecolumn.FieldSource:
 			values[i] = new(sql.NullString)
 		case tablecolumn.FieldCreatedAt, tablecolumn.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -142,12 +147,10 @@ func (tc *TableColumn) assignValues(columns []string, values []any) error {
 				tc.FillMode = tablecolumn.FillMode(value.String)
 			}
 		case tablecolumn.FieldSource:
-			if value, ok := values[i].(*[]byte); !ok {
+			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field source", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &tc.Source); err != nil {
-					return fmt.Errorf("unmarshal field source: %w", err)
-				}
+			} else if value.Valid {
+				tc.Source = value.String
 			}
 		case tablecolumn.FieldContextLength:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -160,6 +163,24 @@ func (tc *TableColumn) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field table_id", values[i])
 			} else if value.Valid {
 				tc.TableID = int(value.Int64)
+			}
+		case tablecolumn.FieldRandom:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field random", values[i])
+			} else if value.Valid {
+				tc.Random = value.Bool
+			}
+		case tablecolumn.FieldReplacement:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field replacement", values[i])
+			} else if value.Valid {
+				tc.Replacement = value.Bool
+			}
+		case tablecolumn.FieldRepeat:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field repeat", values[i])
+			} else if value.Valid {
+				tc.Repeat = int(value.Int64)
 			}
 		default:
 			tc.selectValues.Set(columns[i], values[i])
@@ -224,13 +245,22 @@ func (tc *TableColumn) String() string {
 	builder.WriteString(fmt.Sprintf("%v", tc.FillMode))
 	builder.WriteString(", ")
 	builder.WriteString("source=")
-	builder.WriteString(fmt.Sprintf("%v", tc.Source))
+	builder.WriteString(tc.Source)
 	builder.WriteString(", ")
 	builder.WriteString("context_length=")
 	builder.WriteString(fmt.Sprintf("%v", tc.ContextLength))
 	builder.WriteString(", ")
 	builder.WriteString("table_id=")
 	builder.WriteString(fmt.Sprintf("%v", tc.TableID))
+	builder.WriteString(", ")
+	builder.WriteString("random=")
+	builder.WriteString(fmt.Sprintf("%v", tc.Random))
+	builder.WriteString(", ")
+	builder.WriteString("replacement=")
+	builder.WriteString(fmt.Sprintf("%v", tc.Replacement))
+	builder.WriteString(", ")
+	builder.WriteString("repeat=")
+	builder.WriteString(fmt.Sprintf("%v", tc.Repeat))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/tablecolumn.go
+++ b/ent/tablecolumn.go
@@ -3,6 +3,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -44,6 +45,10 @@ type TableColumn struct {
 	Replacement bool `json:"replacement,omitempty"`
 	// Repeat holds the value of the "repeat" field.
 	Repeat int `json:"repeat,omitempty"`
+	// LinkedColumn holds the value of the "linked_column" field.
+	LinkedColumn string `json:"linked_column,omitempty"`
+	// LinkedContextColumns holds the value of the "linked_context_columns" field.
+	LinkedContextColumns []string `json:"linked_context_columns,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the TableColumnQuery when eager-loading is set.
 	Edges        TableColumnEdges `json:"edges"`
@@ -75,11 +80,13 @@ func (*TableColumn) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
+		case tablecolumn.FieldLinkedContextColumns:
+			values[i] = new([]byte)
 		case tablecolumn.FieldRandom, tablecolumn.FieldReplacement:
 			values[i] = new(sql.NullBool)
 		case tablecolumn.FieldID, tablecolumn.FieldContextLength, tablecolumn.FieldTableID, tablecolumn.FieldRepeat:
 			values[i] = new(sql.NullInt64)
-		case tablecolumn.FieldNanoid, tablecolumn.FieldName, tablecolumn.FieldDescription, tablecolumn.FieldType, tablecolumn.FieldFillMode, tablecolumn.FieldSource:
+		case tablecolumn.FieldNanoid, tablecolumn.FieldName, tablecolumn.FieldDescription, tablecolumn.FieldType, tablecolumn.FieldFillMode, tablecolumn.FieldSource, tablecolumn.FieldLinkedColumn:
 			values[i] = new(sql.NullString)
 		case tablecolumn.FieldCreatedAt, tablecolumn.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -182,6 +189,20 @@ func (tc *TableColumn) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				tc.Repeat = int(value.Int64)
 			}
+		case tablecolumn.FieldLinkedColumn:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field linked_column", values[i])
+			} else if value.Valid {
+				tc.LinkedColumn = value.String
+			}
+		case tablecolumn.FieldLinkedContextColumns:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field linked_context_columns", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &tc.LinkedContextColumns); err != nil {
+					return fmt.Errorf("unmarshal field linked_context_columns: %w", err)
+				}
+			}
 		default:
 			tc.selectValues.Set(columns[i], values[i])
 		}
@@ -261,6 +282,12 @@ func (tc *TableColumn) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("repeat=")
 	builder.WriteString(fmt.Sprintf("%v", tc.Repeat))
+	builder.WriteString(", ")
+	builder.WriteString("linked_column=")
+	builder.WriteString(tc.LinkedColumn)
+	builder.WriteString(", ")
+	builder.WriteString("linked_context_columns=")
+	builder.WriteString(fmt.Sprintf("%v", tc.LinkedContextColumns))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/tablecolumn/tablecolumn.go
+++ b/ent/tablecolumn/tablecolumn.go
@@ -41,6 +41,10 @@ const (
 	FieldReplacement = "replacement"
 	// FieldRepeat holds the string denoting the repeat field in the database.
 	FieldRepeat = "repeat"
+	// FieldLinkedColumn holds the string denoting the linked_column field in the database.
+	FieldLinkedColumn = "linked_column"
+	// FieldLinkedContextColumns holds the string denoting the linked_context_columns field in the database.
+	FieldLinkedContextColumns = "linked_context_columns"
 	// EdgeTablemeta holds the string denoting the tablemeta edge name in mutations.
 	EdgeTablemeta = "tablemeta"
 	// Table holds the table name of the tablecolumn in the database.
@@ -70,6 +74,8 @@ var Columns = []string{
 	FieldRandom,
 	FieldReplacement,
 	FieldRepeat,
+	FieldLinkedColumn,
+	FieldLinkedContextColumns,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -99,6 +105,10 @@ var (
 	DefaultReplacement bool
 	// DefaultRepeat holds the default value on creation for the "repeat" field.
 	DefaultRepeat int
+	// DefaultLinkedColumn holds the default value on creation for the "linked_column" field.
+	DefaultLinkedColumn string
+	// DefaultLinkedContextColumns holds the default value on creation for the "linked_context_columns" field.
+	DefaultLinkedContextColumns []string
 )
 
 // Type defines the type for the "type" enum field.
@@ -221,6 +231,11 @@ func ByReplacement(opts ...sql.OrderTermOption) OrderOption {
 // ByRepeat orders the results by the repeat field.
 func ByRepeat(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRepeat, opts...).ToFunc()
+}
+
+// ByLinkedColumn orders the results by the linked_column field.
+func ByLinkedColumn(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLinkedColumn, opts...).ToFunc()
 }
 
 // ByTablemetaField orders the results by tablemeta field.

--- a/ent/tablecolumn/tablecolumn.go
+++ b/ent/tablecolumn/tablecolumn.go
@@ -35,6 +35,12 @@ const (
 	FieldContextLength = "context_length"
 	// FieldTableID holds the string denoting the table_id field in the database.
 	FieldTableID = "table_id"
+	// FieldRandom holds the string denoting the random field in the database.
+	FieldRandom = "random"
+	// FieldReplacement holds the string denoting the replacement field in the database.
+	FieldReplacement = "replacement"
+	// FieldRepeat holds the string denoting the repeat field in the database.
+	FieldRepeat = "repeat"
 	// EdgeTablemeta holds the string denoting the tablemeta edge name in mutations.
 	EdgeTablemeta = "tablemeta"
 	// Table holds the table name of the tablecolumn in the database.
@@ -61,6 +67,9 @@ var Columns = []string{
 	FieldSource,
 	FieldContextLength,
 	FieldTableID,
+	FieldRandom,
+	FieldReplacement,
+	FieldRepeat,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -84,6 +93,12 @@ var (
 	NameValidator func(string) error
 	// DefaultContextLength holds the default value on creation for the "context_length" field.
 	DefaultContextLength int
+	// DefaultRandom holds the default value on creation for the "random" field.
+	DefaultRandom bool
+	// DefaultReplacement holds the default value on creation for the "replacement" field.
+	DefaultReplacement bool
+	// DefaultRepeat holds the default value on creation for the "repeat" field.
+	DefaultRepeat int
 )
 
 // Type defines the type for the "type" enum field.
@@ -178,6 +193,11 @@ func ByFillMode(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFillMode, opts...).ToFunc()
 }
 
+// BySource orders the results by the source field.
+func BySource(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSource, opts...).ToFunc()
+}
+
 // ByContextLength orders the results by the context_length field.
 func ByContextLength(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldContextLength, opts...).ToFunc()
@@ -186,6 +206,21 @@ func ByContextLength(opts ...sql.OrderTermOption) OrderOption {
 // ByTableID orders the results by the table_id field.
 func ByTableID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTableID, opts...).ToFunc()
+}
+
+// ByRandom orders the results by the random field.
+func ByRandom(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRandom, opts...).ToFunc()
+}
+
+// ByReplacement orders the results by the replacement field.
+func ByReplacement(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldReplacement, opts...).ToFunc()
+}
+
+// ByRepeat orders the results by the repeat field.
+func ByRepeat(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRepeat, opts...).ToFunc()
 }
 
 // ByTablemetaField orders the results by tablemeta field.

--- a/ent/tablecolumn/where.go
+++ b/ent/tablecolumn/where.go
@@ -110,6 +110,11 @@ func Repeat(v int) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldEQ(FieldRepeat, v))
 }
 
+// LinkedColumn applies equality check predicate on the "linked_column" field. It's identical to LinkedColumnEQ.
+func LinkedColumn(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldLinkedColumn, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldEQ(FieldCreatedAt, v))
@@ -658,6 +663,71 @@ func RepeatLT(v int) predicate.TableColumn {
 // RepeatLTE applies the LTE predicate on the "repeat" field.
 func RepeatLTE(v int) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldLTE(FieldRepeat, v))
+}
+
+// LinkedColumnEQ applies the EQ predicate on the "linked_column" field.
+func LinkedColumnEQ(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldLinkedColumn, v))
+}
+
+// LinkedColumnNEQ applies the NEQ predicate on the "linked_column" field.
+func LinkedColumnNEQ(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNEQ(FieldLinkedColumn, v))
+}
+
+// LinkedColumnIn applies the In predicate on the "linked_column" field.
+func LinkedColumnIn(vs ...string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldIn(FieldLinkedColumn, vs...))
+}
+
+// LinkedColumnNotIn applies the NotIn predicate on the "linked_column" field.
+func LinkedColumnNotIn(vs ...string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNotIn(FieldLinkedColumn, vs...))
+}
+
+// LinkedColumnGT applies the GT predicate on the "linked_column" field.
+func LinkedColumnGT(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldGT(FieldLinkedColumn, v))
+}
+
+// LinkedColumnGTE applies the GTE predicate on the "linked_column" field.
+func LinkedColumnGTE(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldGTE(FieldLinkedColumn, v))
+}
+
+// LinkedColumnLT applies the LT predicate on the "linked_column" field.
+func LinkedColumnLT(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldLT(FieldLinkedColumn, v))
+}
+
+// LinkedColumnLTE applies the LTE predicate on the "linked_column" field.
+func LinkedColumnLTE(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldLTE(FieldLinkedColumn, v))
+}
+
+// LinkedColumnContains applies the Contains predicate on the "linked_column" field.
+func LinkedColumnContains(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldContains(FieldLinkedColumn, v))
+}
+
+// LinkedColumnHasPrefix applies the HasPrefix predicate on the "linked_column" field.
+func LinkedColumnHasPrefix(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldHasPrefix(FieldLinkedColumn, v))
+}
+
+// LinkedColumnHasSuffix applies the HasSuffix predicate on the "linked_column" field.
+func LinkedColumnHasSuffix(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldHasSuffix(FieldLinkedColumn, v))
+}
+
+// LinkedColumnEqualFold applies the EqualFold predicate on the "linked_column" field.
+func LinkedColumnEqualFold(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEqualFold(FieldLinkedColumn, v))
+}
+
+// LinkedColumnContainsFold applies the ContainsFold predicate on the "linked_column" field.
+func LinkedColumnContainsFold(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldContainsFold(FieldLinkedColumn, v))
 }
 
 // HasTablemeta applies the HasEdge predicate on the "tablemeta" edge.

--- a/ent/tablecolumn/where.go
+++ b/ent/tablecolumn/where.go
@@ -80,6 +80,11 @@ func Description(v string) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldEQ(FieldDescription, v))
 }
 
+// Source applies equality check predicate on the "source" field. It's identical to SourceEQ.
+func Source(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldSource, v))
+}
+
 // ContextLength applies equality check predicate on the "context_length" field. It's identical to ContextLengthEQ.
 func ContextLength(v int) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldEQ(FieldContextLength, v))
@@ -88,6 +93,21 @@ func ContextLength(v int) predicate.TableColumn {
 // TableID applies equality check predicate on the "table_id" field. It's identical to TableIDEQ.
 func TableID(v int) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldEQ(FieldTableID, v))
+}
+
+// Random applies equality check predicate on the "random" field. It's identical to RandomEQ.
+func Random(v bool) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldRandom, v))
+}
+
+// Replacement applies equality check predicate on the "replacement" field. It's identical to ReplacementEQ.
+func Replacement(v bool) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldReplacement, v))
+}
+
+// Repeat applies equality check predicate on the "repeat" field. It's identical to RepeatEQ.
+func Repeat(v int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldRepeat, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
@@ -445,6 +465,61 @@ func FillModeNotIn(vs ...FillMode) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldNotIn(FieldFillMode, vs...))
 }
 
+// SourceEQ applies the EQ predicate on the "source" field.
+func SourceEQ(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldSource, v))
+}
+
+// SourceNEQ applies the NEQ predicate on the "source" field.
+func SourceNEQ(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNEQ(FieldSource, v))
+}
+
+// SourceIn applies the In predicate on the "source" field.
+func SourceIn(vs ...string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldIn(FieldSource, vs...))
+}
+
+// SourceNotIn applies the NotIn predicate on the "source" field.
+func SourceNotIn(vs ...string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNotIn(FieldSource, vs...))
+}
+
+// SourceGT applies the GT predicate on the "source" field.
+func SourceGT(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldGT(FieldSource, v))
+}
+
+// SourceGTE applies the GTE predicate on the "source" field.
+func SourceGTE(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldGTE(FieldSource, v))
+}
+
+// SourceLT applies the LT predicate on the "source" field.
+func SourceLT(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldLT(FieldSource, v))
+}
+
+// SourceLTE applies the LTE predicate on the "source" field.
+func SourceLTE(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldLTE(FieldSource, v))
+}
+
+// SourceContains applies the Contains predicate on the "source" field.
+func SourceContains(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldContains(FieldSource, v))
+}
+
+// SourceHasPrefix applies the HasPrefix predicate on the "source" field.
+func SourceHasPrefix(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldHasPrefix(FieldSource, v))
+}
+
+// SourceHasSuffix applies the HasSuffix predicate on the "source" field.
+func SourceHasSuffix(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldHasSuffix(FieldSource, v))
+}
+
 // SourceIsNil applies the IsNil predicate on the "source" field.
 func SourceIsNil() predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldIsNull(FieldSource))
@@ -453,6 +528,16 @@ func SourceIsNil() predicate.TableColumn {
 // SourceNotNil applies the NotNil predicate on the "source" field.
 func SourceNotNil() predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldNotNull(FieldSource))
+}
+
+// SourceEqualFold applies the EqualFold predicate on the "source" field.
+func SourceEqualFold(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEqualFold(FieldSource, v))
+}
+
+// SourceContainsFold applies the ContainsFold predicate on the "source" field.
+func SourceContainsFold(v string) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldContainsFold(FieldSource, v))
 }
 
 // ContextLengthEQ applies the EQ predicate on the "context_length" field.
@@ -513,6 +598,66 @@ func TableIDIn(vs ...int) predicate.TableColumn {
 // TableIDNotIn applies the NotIn predicate on the "table_id" field.
 func TableIDNotIn(vs ...int) predicate.TableColumn {
 	return predicate.TableColumn(sql.FieldNotIn(FieldTableID, vs...))
+}
+
+// RandomEQ applies the EQ predicate on the "random" field.
+func RandomEQ(v bool) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldRandom, v))
+}
+
+// RandomNEQ applies the NEQ predicate on the "random" field.
+func RandomNEQ(v bool) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNEQ(FieldRandom, v))
+}
+
+// ReplacementEQ applies the EQ predicate on the "replacement" field.
+func ReplacementEQ(v bool) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldReplacement, v))
+}
+
+// ReplacementNEQ applies the NEQ predicate on the "replacement" field.
+func ReplacementNEQ(v bool) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNEQ(FieldReplacement, v))
+}
+
+// RepeatEQ applies the EQ predicate on the "repeat" field.
+func RepeatEQ(v int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldEQ(FieldRepeat, v))
+}
+
+// RepeatNEQ applies the NEQ predicate on the "repeat" field.
+func RepeatNEQ(v int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNEQ(FieldRepeat, v))
+}
+
+// RepeatIn applies the In predicate on the "repeat" field.
+func RepeatIn(vs ...int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldIn(FieldRepeat, vs...))
+}
+
+// RepeatNotIn applies the NotIn predicate on the "repeat" field.
+func RepeatNotIn(vs ...int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldNotIn(FieldRepeat, vs...))
+}
+
+// RepeatGT applies the GT predicate on the "repeat" field.
+func RepeatGT(v int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldGT(FieldRepeat, v))
+}
+
+// RepeatGTE applies the GTE predicate on the "repeat" field.
+func RepeatGTE(v int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldGTE(FieldRepeat, v))
+}
+
+// RepeatLT applies the LT predicate on the "repeat" field.
+func RepeatLT(v int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldLT(FieldRepeat, v))
+}
+
+// RepeatLTE applies the LTE predicate on the "repeat" field.
+func RepeatLTE(v int) predicate.TableColumn {
+	return predicate.TableColumn(sql.FieldLTE(FieldRepeat, v))
 }
 
 // HasTablemeta applies the HasEdge predicate on the "tablemeta" edge.

--- a/ent/tablecolumn_create.go
+++ b/ent/tablecolumn_create.go
@@ -173,6 +173,26 @@ func (tcc *TableColumnCreate) SetNillableRepeat(i *int) *TableColumnCreate {
 	return tcc
 }
 
+// SetLinkedColumn sets the "linked_column" field.
+func (tcc *TableColumnCreate) SetLinkedColumn(s string) *TableColumnCreate {
+	tcc.mutation.SetLinkedColumn(s)
+	return tcc
+}
+
+// SetNillableLinkedColumn sets the "linked_column" field if the given value is not nil.
+func (tcc *TableColumnCreate) SetNillableLinkedColumn(s *string) *TableColumnCreate {
+	if s != nil {
+		tcc.SetLinkedColumn(*s)
+	}
+	return tcc
+}
+
+// SetLinkedContextColumns sets the "linked_context_columns" field.
+func (tcc *TableColumnCreate) SetLinkedContextColumns(s []string) *TableColumnCreate {
+	tcc.mutation.SetLinkedContextColumns(s)
+	return tcc
+}
+
 // SetTablemetaID sets the "tablemeta" edge to the TableMeta entity by ID.
 func (tcc *TableColumnCreate) SetTablemetaID(id int) *TableColumnCreate {
 	tcc.mutation.SetTablemetaID(id)
@@ -243,6 +263,14 @@ func (tcc *TableColumnCreate) defaults() {
 		v := tablecolumn.DefaultRepeat
 		tcc.mutation.SetRepeat(v)
 	}
+	if _, ok := tcc.mutation.LinkedColumn(); !ok {
+		v := tablecolumn.DefaultLinkedColumn
+		tcc.mutation.SetLinkedColumn(v)
+	}
+	if _, ok := tcc.mutation.LinkedContextColumns(); !ok {
+		v := tablecolumn.DefaultLinkedContextColumns
+		tcc.mutation.SetLinkedContextColumns(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -285,6 +313,12 @@ func (tcc *TableColumnCreate) check() error {
 	}
 	if _, ok := tcc.mutation.Repeat(); !ok {
 		return &ValidationError{Name: "repeat", err: errors.New(`ent: missing required field "TableColumn.repeat"`)}
+	}
+	if _, ok := tcc.mutation.LinkedColumn(); !ok {
+		return &ValidationError{Name: "linked_column", err: errors.New(`ent: missing required field "TableColumn.linked_column"`)}
+	}
+	if _, ok := tcc.mutation.LinkedContextColumns(); !ok {
+		return &ValidationError{Name: "linked_context_columns", err: errors.New(`ent: missing required field "TableColumn.linked_context_columns"`)}
 	}
 	if len(tcc.mutation.TablemetaIDs()) == 0 {
 		return &ValidationError{Name: "tablemeta", err: errors.New(`ent: missing required edge "TableColumn.tablemeta"`)}
@@ -363,6 +397,14 @@ func (tcc *TableColumnCreate) createSpec() (*TableColumn, *sqlgraph.CreateSpec) 
 	if value, ok := tcc.mutation.Repeat(); ok {
 		_spec.SetField(tablecolumn.FieldRepeat, field.TypeInt, value)
 		_node.Repeat = value
+	}
+	if value, ok := tcc.mutation.LinkedColumn(); ok {
+		_spec.SetField(tablecolumn.FieldLinkedColumn, field.TypeString, value)
+		_node.LinkedColumn = value
+	}
+	if value, ok := tcc.mutation.LinkedContextColumns(); ok {
+		_spec.SetField(tablecolumn.FieldLinkedContextColumns, field.TypeJSON, value)
+		_node.LinkedContextColumns = value
 	}
 	if nodes := tcc.mutation.TablemetaIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -610,6 +652,30 @@ func (u *TableColumnUpsert) UpdateRepeat() *TableColumnUpsert {
 // AddRepeat adds v to the "repeat" field.
 func (u *TableColumnUpsert) AddRepeat(v int) *TableColumnUpsert {
 	u.Add(tablecolumn.FieldRepeat, v)
+	return u
+}
+
+// SetLinkedColumn sets the "linked_column" field.
+func (u *TableColumnUpsert) SetLinkedColumn(v string) *TableColumnUpsert {
+	u.Set(tablecolumn.FieldLinkedColumn, v)
+	return u
+}
+
+// UpdateLinkedColumn sets the "linked_column" field to the value that was provided on create.
+func (u *TableColumnUpsert) UpdateLinkedColumn() *TableColumnUpsert {
+	u.SetExcluded(tablecolumn.FieldLinkedColumn)
+	return u
+}
+
+// SetLinkedContextColumns sets the "linked_context_columns" field.
+func (u *TableColumnUpsert) SetLinkedContextColumns(v []string) *TableColumnUpsert {
+	u.Set(tablecolumn.FieldLinkedContextColumns, v)
+	return u
+}
+
+// UpdateLinkedContextColumns sets the "linked_context_columns" field to the value that was provided on create.
+func (u *TableColumnUpsert) UpdateLinkedContextColumns() *TableColumnUpsert {
+	u.SetExcluded(tablecolumn.FieldLinkedContextColumns)
 	return u
 }
 
@@ -865,6 +931,34 @@ func (u *TableColumnUpsertOne) AddRepeat(v int) *TableColumnUpsertOne {
 func (u *TableColumnUpsertOne) UpdateRepeat() *TableColumnUpsertOne {
 	return u.Update(func(s *TableColumnUpsert) {
 		s.UpdateRepeat()
+	})
+}
+
+// SetLinkedColumn sets the "linked_column" field.
+func (u *TableColumnUpsertOne) SetLinkedColumn(v string) *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetLinkedColumn(v)
+	})
+}
+
+// UpdateLinkedColumn sets the "linked_column" field to the value that was provided on create.
+func (u *TableColumnUpsertOne) UpdateLinkedColumn() *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateLinkedColumn()
+	})
+}
+
+// SetLinkedContextColumns sets the "linked_context_columns" field.
+func (u *TableColumnUpsertOne) SetLinkedContextColumns(v []string) *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetLinkedContextColumns(v)
+	})
+}
+
+// UpdateLinkedContextColumns sets the "linked_context_columns" field to the value that was provided on create.
+func (u *TableColumnUpsertOne) UpdateLinkedContextColumns() *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateLinkedContextColumns()
 	})
 }
 
@@ -1286,6 +1380,34 @@ func (u *TableColumnUpsertBulk) AddRepeat(v int) *TableColumnUpsertBulk {
 func (u *TableColumnUpsertBulk) UpdateRepeat() *TableColumnUpsertBulk {
 	return u.Update(func(s *TableColumnUpsert) {
 		s.UpdateRepeat()
+	})
+}
+
+// SetLinkedColumn sets the "linked_column" field.
+func (u *TableColumnUpsertBulk) SetLinkedColumn(v string) *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetLinkedColumn(v)
+	})
+}
+
+// UpdateLinkedColumn sets the "linked_column" field to the value that was provided on create.
+func (u *TableColumnUpsertBulk) UpdateLinkedColumn() *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateLinkedColumn()
+	})
+}
+
+// SetLinkedContextColumns sets the "linked_context_columns" field.
+func (u *TableColumnUpsertBulk) SetLinkedContextColumns(v []string) *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetLinkedContextColumns(v)
+	})
+}
+
+// UpdateLinkedContextColumns sets the "linked_context_columns" field to the value that was provided on create.
+func (u *TableColumnUpsertBulk) UpdateLinkedContextColumns() *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateLinkedContextColumns()
 	})
 }
 

--- a/ent/tablecolumn_create.go
+++ b/ent/tablecolumn_create.go
@@ -4,7 +4,6 @@ package ent
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -99,8 +98,16 @@ func (tcc *TableColumnCreate) SetFillMode(tm tablecolumn.FillMode) *TableColumnC
 }
 
 // SetSource sets the "source" field.
-func (tcc *TableColumnCreate) SetSource(jm json.RawMessage) *TableColumnCreate {
-	tcc.mutation.SetSource(jm)
+func (tcc *TableColumnCreate) SetSource(s string) *TableColumnCreate {
+	tcc.mutation.SetSource(s)
+	return tcc
+}
+
+// SetNillableSource sets the "source" field if the given value is not nil.
+func (tcc *TableColumnCreate) SetNillableSource(s *string) *TableColumnCreate {
+	if s != nil {
+		tcc.SetSource(*s)
+	}
 	return tcc
 }
 
@@ -121,6 +128,48 @@ func (tcc *TableColumnCreate) SetNillableContextLength(i *int) *TableColumnCreat
 // SetTableID sets the "table_id" field.
 func (tcc *TableColumnCreate) SetTableID(i int) *TableColumnCreate {
 	tcc.mutation.SetTableID(i)
+	return tcc
+}
+
+// SetRandom sets the "random" field.
+func (tcc *TableColumnCreate) SetRandom(b bool) *TableColumnCreate {
+	tcc.mutation.SetRandom(b)
+	return tcc
+}
+
+// SetNillableRandom sets the "random" field if the given value is not nil.
+func (tcc *TableColumnCreate) SetNillableRandom(b *bool) *TableColumnCreate {
+	if b != nil {
+		tcc.SetRandom(*b)
+	}
+	return tcc
+}
+
+// SetReplacement sets the "replacement" field.
+func (tcc *TableColumnCreate) SetReplacement(b bool) *TableColumnCreate {
+	tcc.mutation.SetReplacement(b)
+	return tcc
+}
+
+// SetNillableReplacement sets the "replacement" field if the given value is not nil.
+func (tcc *TableColumnCreate) SetNillableReplacement(b *bool) *TableColumnCreate {
+	if b != nil {
+		tcc.SetReplacement(*b)
+	}
+	return tcc
+}
+
+// SetRepeat sets the "repeat" field.
+func (tcc *TableColumnCreate) SetRepeat(i int) *TableColumnCreate {
+	tcc.mutation.SetRepeat(i)
+	return tcc
+}
+
+// SetNillableRepeat sets the "repeat" field if the given value is not nil.
+func (tcc *TableColumnCreate) SetNillableRepeat(i *int) *TableColumnCreate {
+	if i != nil {
+		tcc.SetRepeat(*i)
+	}
 	return tcc
 }
 
@@ -182,6 +231,18 @@ func (tcc *TableColumnCreate) defaults() {
 		v := tablecolumn.DefaultContextLength
 		tcc.mutation.SetContextLength(v)
 	}
+	if _, ok := tcc.mutation.Random(); !ok {
+		v := tablecolumn.DefaultRandom
+		tcc.mutation.SetRandom(v)
+	}
+	if _, ok := tcc.mutation.Replacement(); !ok {
+		v := tablecolumn.DefaultReplacement
+		tcc.mutation.SetReplacement(v)
+	}
+	if _, ok := tcc.mutation.Repeat(); !ok {
+		v := tablecolumn.DefaultRepeat
+		tcc.mutation.SetRepeat(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -215,6 +276,15 @@ func (tcc *TableColumnCreate) check() error {
 	}
 	if _, ok := tcc.mutation.TableID(); !ok {
 		return &ValidationError{Name: "table_id", err: errors.New(`ent: missing required field "TableColumn.table_id"`)}
+	}
+	if _, ok := tcc.mutation.Random(); !ok {
+		return &ValidationError{Name: "random", err: errors.New(`ent: missing required field "TableColumn.random"`)}
+	}
+	if _, ok := tcc.mutation.Replacement(); !ok {
+		return &ValidationError{Name: "replacement", err: errors.New(`ent: missing required field "TableColumn.replacement"`)}
+	}
+	if _, ok := tcc.mutation.Repeat(); !ok {
+		return &ValidationError{Name: "repeat", err: errors.New(`ent: missing required field "TableColumn.repeat"`)}
 	}
 	if len(tcc.mutation.TablemetaIDs()) == 0 {
 		return &ValidationError{Name: "tablemeta", err: errors.New(`ent: missing required edge "TableColumn.tablemeta"`)}
@@ -275,12 +345,24 @@ func (tcc *TableColumnCreate) createSpec() (*TableColumn, *sqlgraph.CreateSpec) 
 		_node.FillMode = value
 	}
 	if value, ok := tcc.mutation.Source(); ok {
-		_spec.SetField(tablecolumn.FieldSource, field.TypeJSON, value)
+		_spec.SetField(tablecolumn.FieldSource, field.TypeString, value)
 		_node.Source = value
 	}
 	if value, ok := tcc.mutation.ContextLength(); ok {
 		_spec.SetField(tablecolumn.FieldContextLength, field.TypeInt, value)
 		_node.ContextLength = value
+	}
+	if value, ok := tcc.mutation.Random(); ok {
+		_spec.SetField(tablecolumn.FieldRandom, field.TypeBool, value)
+		_node.Random = value
+	}
+	if value, ok := tcc.mutation.Replacement(); ok {
+		_spec.SetField(tablecolumn.FieldReplacement, field.TypeBool, value)
+		_node.Replacement = value
+	}
+	if value, ok := tcc.mutation.Repeat(); ok {
+		_spec.SetField(tablecolumn.FieldRepeat, field.TypeInt, value)
+		_node.Repeat = value
 	}
 	if nodes := tcc.mutation.TablemetaIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -442,7 +524,7 @@ func (u *TableColumnUpsert) UpdateFillMode() *TableColumnUpsert {
 }
 
 // SetSource sets the "source" field.
-func (u *TableColumnUpsert) SetSource(v json.RawMessage) *TableColumnUpsert {
+func (u *TableColumnUpsert) SetSource(v string) *TableColumnUpsert {
 	u.Set(tablecolumn.FieldSource, v)
 	return u
 }
@@ -486,6 +568,48 @@ func (u *TableColumnUpsert) SetTableID(v int) *TableColumnUpsert {
 // UpdateTableID sets the "table_id" field to the value that was provided on create.
 func (u *TableColumnUpsert) UpdateTableID() *TableColumnUpsert {
 	u.SetExcluded(tablecolumn.FieldTableID)
+	return u
+}
+
+// SetRandom sets the "random" field.
+func (u *TableColumnUpsert) SetRandom(v bool) *TableColumnUpsert {
+	u.Set(tablecolumn.FieldRandom, v)
+	return u
+}
+
+// UpdateRandom sets the "random" field to the value that was provided on create.
+func (u *TableColumnUpsert) UpdateRandom() *TableColumnUpsert {
+	u.SetExcluded(tablecolumn.FieldRandom)
+	return u
+}
+
+// SetReplacement sets the "replacement" field.
+func (u *TableColumnUpsert) SetReplacement(v bool) *TableColumnUpsert {
+	u.Set(tablecolumn.FieldReplacement, v)
+	return u
+}
+
+// UpdateReplacement sets the "replacement" field to the value that was provided on create.
+func (u *TableColumnUpsert) UpdateReplacement() *TableColumnUpsert {
+	u.SetExcluded(tablecolumn.FieldReplacement)
+	return u
+}
+
+// SetRepeat sets the "repeat" field.
+func (u *TableColumnUpsert) SetRepeat(v int) *TableColumnUpsert {
+	u.Set(tablecolumn.FieldRepeat, v)
+	return u
+}
+
+// UpdateRepeat sets the "repeat" field to the value that was provided on create.
+func (u *TableColumnUpsert) UpdateRepeat() *TableColumnUpsert {
+	u.SetExcluded(tablecolumn.FieldRepeat)
+	return u
+}
+
+// AddRepeat adds v to the "repeat" field.
+func (u *TableColumnUpsert) AddRepeat(v int) *TableColumnUpsert {
+	u.Add(tablecolumn.FieldRepeat, v)
 	return u
 }
 
@@ -640,7 +764,7 @@ func (u *TableColumnUpsertOne) UpdateFillMode() *TableColumnUpsertOne {
 }
 
 // SetSource sets the "source" field.
-func (u *TableColumnUpsertOne) SetSource(v json.RawMessage) *TableColumnUpsertOne {
+func (u *TableColumnUpsertOne) SetSource(v string) *TableColumnUpsertOne {
 	return u.Update(func(s *TableColumnUpsert) {
 		s.SetSource(v)
 	})
@@ -692,6 +816,55 @@ func (u *TableColumnUpsertOne) SetTableID(v int) *TableColumnUpsertOne {
 func (u *TableColumnUpsertOne) UpdateTableID() *TableColumnUpsertOne {
 	return u.Update(func(s *TableColumnUpsert) {
 		s.UpdateTableID()
+	})
+}
+
+// SetRandom sets the "random" field.
+func (u *TableColumnUpsertOne) SetRandom(v bool) *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetRandom(v)
+	})
+}
+
+// UpdateRandom sets the "random" field to the value that was provided on create.
+func (u *TableColumnUpsertOne) UpdateRandom() *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateRandom()
+	})
+}
+
+// SetReplacement sets the "replacement" field.
+func (u *TableColumnUpsertOne) SetReplacement(v bool) *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetReplacement(v)
+	})
+}
+
+// UpdateReplacement sets the "replacement" field to the value that was provided on create.
+func (u *TableColumnUpsertOne) UpdateReplacement() *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateReplacement()
+	})
+}
+
+// SetRepeat sets the "repeat" field.
+func (u *TableColumnUpsertOne) SetRepeat(v int) *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetRepeat(v)
+	})
+}
+
+// AddRepeat adds v to the "repeat" field.
+func (u *TableColumnUpsertOne) AddRepeat(v int) *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.AddRepeat(v)
+	})
+}
+
+// UpdateRepeat sets the "repeat" field to the value that was provided on create.
+func (u *TableColumnUpsertOne) UpdateRepeat() *TableColumnUpsertOne {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateRepeat()
 	})
 }
 
@@ -1012,7 +1185,7 @@ func (u *TableColumnUpsertBulk) UpdateFillMode() *TableColumnUpsertBulk {
 }
 
 // SetSource sets the "source" field.
-func (u *TableColumnUpsertBulk) SetSource(v json.RawMessage) *TableColumnUpsertBulk {
+func (u *TableColumnUpsertBulk) SetSource(v string) *TableColumnUpsertBulk {
 	return u.Update(func(s *TableColumnUpsert) {
 		s.SetSource(v)
 	})
@@ -1064,6 +1237,55 @@ func (u *TableColumnUpsertBulk) SetTableID(v int) *TableColumnUpsertBulk {
 func (u *TableColumnUpsertBulk) UpdateTableID() *TableColumnUpsertBulk {
 	return u.Update(func(s *TableColumnUpsert) {
 		s.UpdateTableID()
+	})
+}
+
+// SetRandom sets the "random" field.
+func (u *TableColumnUpsertBulk) SetRandom(v bool) *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetRandom(v)
+	})
+}
+
+// UpdateRandom sets the "random" field to the value that was provided on create.
+func (u *TableColumnUpsertBulk) UpdateRandom() *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateRandom()
+	})
+}
+
+// SetReplacement sets the "replacement" field.
+func (u *TableColumnUpsertBulk) SetReplacement(v bool) *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetReplacement(v)
+	})
+}
+
+// UpdateReplacement sets the "replacement" field to the value that was provided on create.
+func (u *TableColumnUpsertBulk) UpdateReplacement() *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateReplacement()
+	})
+}
+
+// SetRepeat sets the "repeat" field.
+func (u *TableColumnUpsertBulk) SetRepeat(v int) *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.SetRepeat(v)
+	})
+}
+
+// AddRepeat adds v to the "repeat" field.
+func (u *TableColumnUpsertBulk) AddRepeat(v int) *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.AddRepeat(v)
+	})
+}
+
+// UpdateRepeat sets the "repeat" field to the value that was provided on create.
+func (u *TableColumnUpsertBulk) UpdateRepeat() *TableColumnUpsertBulk {
+	return u.Update(func(s *TableColumnUpsert) {
+		s.UpdateRepeat()
 	})
 }
 

--- a/ent/tablecolumn_update.go
+++ b/ent/tablecolumn_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/Yiling-J/tablepilot/ent/predicate"
 	"github.com/Yiling-J/tablepilot/ent/tablecolumn"
@@ -228,6 +229,32 @@ func (tcu *TableColumnUpdate) AddRepeat(i int) *TableColumnUpdate {
 	return tcu
 }
 
+// SetLinkedColumn sets the "linked_column" field.
+func (tcu *TableColumnUpdate) SetLinkedColumn(s string) *TableColumnUpdate {
+	tcu.mutation.SetLinkedColumn(s)
+	return tcu
+}
+
+// SetNillableLinkedColumn sets the "linked_column" field if the given value is not nil.
+func (tcu *TableColumnUpdate) SetNillableLinkedColumn(s *string) *TableColumnUpdate {
+	if s != nil {
+		tcu.SetLinkedColumn(*s)
+	}
+	return tcu
+}
+
+// SetLinkedContextColumns sets the "linked_context_columns" field.
+func (tcu *TableColumnUpdate) SetLinkedContextColumns(s []string) *TableColumnUpdate {
+	tcu.mutation.SetLinkedContextColumns(s)
+	return tcu
+}
+
+// AppendLinkedContextColumns appends s to the "linked_context_columns" field.
+func (tcu *TableColumnUpdate) AppendLinkedContextColumns(s []string) *TableColumnUpdate {
+	tcu.mutation.AppendLinkedContextColumns(s)
+	return tcu
+}
+
 // SetTablemetaID sets the "tablemeta" edge to the TableMeta entity by ID.
 func (tcu *TableColumnUpdate) SetTablemetaID(id int) *TableColumnUpdate {
 	tcu.mutation.SetTablemetaID(id)
@@ -380,6 +407,17 @@ func (tcu *TableColumnUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := tcu.mutation.AddedRepeat(); ok {
 		_spec.AddField(tablecolumn.FieldRepeat, field.TypeInt, value)
+	}
+	if value, ok := tcu.mutation.LinkedColumn(); ok {
+		_spec.SetField(tablecolumn.FieldLinkedColumn, field.TypeString, value)
+	}
+	if value, ok := tcu.mutation.LinkedContextColumns(); ok {
+		_spec.SetField(tablecolumn.FieldLinkedContextColumns, field.TypeJSON, value)
+	}
+	if value, ok := tcu.mutation.AppendedLinkedContextColumns(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, tablecolumn.FieldLinkedContextColumns, value)
+		})
 	}
 	if tcu.mutation.TablemetaCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -630,6 +668,32 @@ func (tcuo *TableColumnUpdateOne) AddRepeat(i int) *TableColumnUpdateOne {
 	return tcuo
 }
 
+// SetLinkedColumn sets the "linked_column" field.
+func (tcuo *TableColumnUpdateOne) SetLinkedColumn(s string) *TableColumnUpdateOne {
+	tcuo.mutation.SetLinkedColumn(s)
+	return tcuo
+}
+
+// SetNillableLinkedColumn sets the "linked_column" field if the given value is not nil.
+func (tcuo *TableColumnUpdateOne) SetNillableLinkedColumn(s *string) *TableColumnUpdateOne {
+	if s != nil {
+		tcuo.SetLinkedColumn(*s)
+	}
+	return tcuo
+}
+
+// SetLinkedContextColumns sets the "linked_context_columns" field.
+func (tcuo *TableColumnUpdateOne) SetLinkedContextColumns(s []string) *TableColumnUpdateOne {
+	tcuo.mutation.SetLinkedContextColumns(s)
+	return tcuo
+}
+
+// AppendLinkedContextColumns appends s to the "linked_context_columns" field.
+func (tcuo *TableColumnUpdateOne) AppendLinkedContextColumns(s []string) *TableColumnUpdateOne {
+	tcuo.mutation.AppendLinkedContextColumns(s)
+	return tcuo
+}
+
 // SetTablemetaID sets the "tablemeta" edge to the TableMeta entity by ID.
 func (tcuo *TableColumnUpdateOne) SetTablemetaID(id int) *TableColumnUpdateOne {
 	tcuo.mutation.SetTablemetaID(id)
@@ -812,6 +876,17 @@ func (tcuo *TableColumnUpdateOne) sqlSave(ctx context.Context) (_node *TableColu
 	}
 	if value, ok := tcuo.mutation.AddedRepeat(); ok {
 		_spec.AddField(tablecolumn.FieldRepeat, field.TypeInt, value)
+	}
+	if value, ok := tcuo.mutation.LinkedColumn(); ok {
+		_spec.SetField(tablecolumn.FieldLinkedColumn, field.TypeString, value)
+	}
+	if value, ok := tcuo.mutation.LinkedContextColumns(); ok {
+		_spec.SetField(tablecolumn.FieldLinkedContextColumns, field.TypeJSON, value)
+	}
+	if value, ok := tcuo.mutation.AppendedLinkedContextColumns(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, tablecolumn.FieldLinkedContextColumns, value)
+		})
 	}
 	if tcuo.mutation.TablemetaCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/tablecolumn_update.go
+++ b/ent/tablecolumn_update.go
@@ -4,14 +4,12 @@ package ent
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
-	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/Yiling-J/tablepilot/ent/predicate"
 	"github.com/Yiling-J/tablepilot/ent/tablecolumn"
@@ -127,14 +125,16 @@ func (tcu *TableColumnUpdate) SetNillableFillMode(tm *tablecolumn.FillMode) *Tab
 }
 
 // SetSource sets the "source" field.
-func (tcu *TableColumnUpdate) SetSource(jm json.RawMessage) *TableColumnUpdate {
-	tcu.mutation.SetSource(jm)
+func (tcu *TableColumnUpdate) SetSource(s string) *TableColumnUpdate {
+	tcu.mutation.SetSource(s)
 	return tcu
 }
 
-// AppendSource appends jm to the "source" field.
-func (tcu *TableColumnUpdate) AppendSource(jm json.RawMessage) *TableColumnUpdate {
-	tcu.mutation.AppendSource(jm)
+// SetNillableSource sets the "source" field if the given value is not nil.
+func (tcu *TableColumnUpdate) SetNillableSource(s *string) *TableColumnUpdate {
+	if s != nil {
+		tcu.SetSource(*s)
+	}
 	return tcu
 }
 
@@ -176,6 +176,55 @@ func (tcu *TableColumnUpdate) SetNillableTableID(i *int) *TableColumnUpdate {
 	if i != nil {
 		tcu.SetTableID(*i)
 	}
+	return tcu
+}
+
+// SetRandom sets the "random" field.
+func (tcu *TableColumnUpdate) SetRandom(b bool) *TableColumnUpdate {
+	tcu.mutation.SetRandom(b)
+	return tcu
+}
+
+// SetNillableRandom sets the "random" field if the given value is not nil.
+func (tcu *TableColumnUpdate) SetNillableRandom(b *bool) *TableColumnUpdate {
+	if b != nil {
+		tcu.SetRandom(*b)
+	}
+	return tcu
+}
+
+// SetReplacement sets the "replacement" field.
+func (tcu *TableColumnUpdate) SetReplacement(b bool) *TableColumnUpdate {
+	tcu.mutation.SetReplacement(b)
+	return tcu
+}
+
+// SetNillableReplacement sets the "replacement" field if the given value is not nil.
+func (tcu *TableColumnUpdate) SetNillableReplacement(b *bool) *TableColumnUpdate {
+	if b != nil {
+		tcu.SetReplacement(*b)
+	}
+	return tcu
+}
+
+// SetRepeat sets the "repeat" field.
+func (tcu *TableColumnUpdate) SetRepeat(i int) *TableColumnUpdate {
+	tcu.mutation.ResetRepeat()
+	tcu.mutation.SetRepeat(i)
+	return tcu
+}
+
+// SetNillableRepeat sets the "repeat" field if the given value is not nil.
+func (tcu *TableColumnUpdate) SetNillableRepeat(i *int) *TableColumnUpdate {
+	if i != nil {
+		tcu.SetRepeat(*i)
+	}
+	return tcu
+}
+
+// AddRepeat adds i to the "repeat" field.
+func (tcu *TableColumnUpdate) AddRepeat(i int) *TableColumnUpdate {
+	tcu.mutation.AddRepeat(i)
 	return tcu
 }
 
@@ -309,21 +358,28 @@ func (tcu *TableColumnUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		_spec.SetField(tablecolumn.FieldFillMode, field.TypeEnum, value)
 	}
 	if value, ok := tcu.mutation.Source(); ok {
-		_spec.SetField(tablecolumn.FieldSource, field.TypeJSON, value)
-	}
-	if value, ok := tcu.mutation.AppendedSource(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, tablecolumn.FieldSource, value)
-		})
+		_spec.SetField(tablecolumn.FieldSource, field.TypeString, value)
 	}
 	if tcu.mutation.SourceCleared() {
-		_spec.ClearField(tablecolumn.FieldSource, field.TypeJSON)
+		_spec.ClearField(tablecolumn.FieldSource, field.TypeString)
 	}
 	if value, ok := tcu.mutation.ContextLength(); ok {
 		_spec.SetField(tablecolumn.FieldContextLength, field.TypeInt, value)
 	}
 	if value, ok := tcu.mutation.AddedContextLength(); ok {
 		_spec.AddField(tablecolumn.FieldContextLength, field.TypeInt, value)
+	}
+	if value, ok := tcu.mutation.Random(); ok {
+		_spec.SetField(tablecolumn.FieldRandom, field.TypeBool, value)
+	}
+	if value, ok := tcu.mutation.Replacement(); ok {
+		_spec.SetField(tablecolumn.FieldReplacement, field.TypeBool, value)
+	}
+	if value, ok := tcu.mutation.Repeat(); ok {
+		_spec.SetField(tablecolumn.FieldRepeat, field.TypeInt, value)
+	}
+	if value, ok := tcu.mutation.AddedRepeat(); ok {
+		_spec.AddField(tablecolumn.FieldRepeat, field.TypeInt, value)
 	}
 	if tcu.mutation.TablemetaCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -471,14 +527,16 @@ func (tcuo *TableColumnUpdateOne) SetNillableFillMode(tm *tablecolumn.FillMode) 
 }
 
 // SetSource sets the "source" field.
-func (tcuo *TableColumnUpdateOne) SetSource(jm json.RawMessage) *TableColumnUpdateOne {
-	tcuo.mutation.SetSource(jm)
+func (tcuo *TableColumnUpdateOne) SetSource(s string) *TableColumnUpdateOne {
+	tcuo.mutation.SetSource(s)
 	return tcuo
 }
 
-// AppendSource appends jm to the "source" field.
-func (tcuo *TableColumnUpdateOne) AppendSource(jm json.RawMessage) *TableColumnUpdateOne {
-	tcuo.mutation.AppendSource(jm)
+// SetNillableSource sets the "source" field if the given value is not nil.
+func (tcuo *TableColumnUpdateOne) SetNillableSource(s *string) *TableColumnUpdateOne {
+	if s != nil {
+		tcuo.SetSource(*s)
+	}
 	return tcuo
 }
 
@@ -520,6 +578,55 @@ func (tcuo *TableColumnUpdateOne) SetNillableTableID(i *int) *TableColumnUpdateO
 	if i != nil {
 		tcuo.SetTableID(*i)
 	}
+	return tcuo
+}
+
+// SetRandom sets the "random" field.
+func (tcuo *TableColumnUpdateOne) SetRandom(b bool) *TableColumnUpdateOne {
+	tcuo.mutation.SetRandom(b)
+	return tcuo
+}
+
+// SetNillableRandom sets the "random" field if the given value is not nil.
+func (tcuo *TableColumnUpdateOne) SetNillableRandom(b *bool) *TableColumnUpdateOne {
+	if b != nil {
+		tcuo.SetRandom(*b)
+	}
+	return tcuo
+}
+
+// SetReplacement sets the "replacement" field.
+func (tcuo *TableColumnUpdateOne) SetReplacement(b bool) *TableColumnUpdateOne {
+	tcuo.mutation.SetReplacement(b)
+	return tcuo
+}
+
+// SetNillableReplacement sets the "replacement" field if the given value is not nil.
+func (tcuo *TableColumnUpdateOne) SetNillableReplacement(b *bool) *TableColumnUpdateOne {
+	if b != nil {
+		tcuo.SetReplacement(*b)
+	}
+	return tcuo
+}
+
+// SetRepeat sets the "repeat" field.
+func (tcuo *TableColumnUpdateOne) SetRepeat(i int) *TableColumnUpdateOne {
+	tcuo.mutation.ResetRepeat()
+	tcuo.mutation.SetRepeat(i)
+	return tcuo
+}
+
+// SetNillableRepeat sets the "repeat" field if the given value is not nil.
+func (tcuo *TableColumnUpdateOne) SetNillableRepeat(i *int) *TableColumnUpdateOne {
+	if i != nil {
+		tcuo.SetRepeat(*i)
+	}
+	return tcuo
+}
+
+// AddRepeat adds i to the "repeat" field.
+func (tcuo *TableColumnUpdateOne) AddRepeat(i int) *TableColumnUpdateOne {
+	tcuo.mutation.AddRepeat(i)
 	return tcuo
 }
 
@@ -683,21 +790,28 @@ func (tcuo *TableColumnUpdateOne) sqlSave(ctx context.Context) (_node *TableColu
 		_spec.SetField(tablecolumn.FieldFillMode, field.TypeEnum, value)
 	}
 	if value, ok := tcuo.mutation.Source(); ok {
-		_spec.SetField(tablecolumn.FieldSource, field.TypeJSON, value)
-	}
-	if value, ok := tcuo.mutation.AppendedSource(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, tablecolumn.FieldSource, value)
-		})
+		_spec.SetField(tablecolumn.FieldSource, field.TypeString, value)
 	}
 	if tcuo.mutation.SourceCleared() {
-		_spec.ClearField(tablecolumn.FieldSource, field.TypeJSON)
+		_spec.ClearField(tablecolumn.FieldSource, field.TypeString)
 	}
 	if value, ok := tcuo.mutation.ContextLength(); ok {
 		_spec.SetField(tablecolumn.FieldContextLength, field.TypeInt, value)
 	}
 	if value, ok := tcuo.mutation.AddedContextLength(); ok {
 		_spec.AddField(tablecolumn.FieldContextLength, field.TypeInt, value)
+	}
+	if value, ok := tcuo.mutation.Random(); ok {
+		_spec.SetField(tablecolumn.FieldRandom, field.TypeBool, value)
+	}
+	if value, ok := tcuo.mutation.Replacement(); ok {
+		_spec.SetField(tablecolumn.FieldReplacement, field.TypeBool, value)
+	}
+	if value, ok := tcuo.mutation.Repeat(); ok {
+		_spec.SetField(tablecolumn.FieldRepeat, field.TypeInt, value)
+	}
+	if value, ok := tcuo.mutation.AddedRepeat(); ok {
+		_spec.AddField(tablecolumn.FieldRepeat, field.TypeInt, value)
 	}
 	if tcuo.mutation.TablemetaCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/tablemeta.go
+++ b/ent/tablemeta.go
@@ -3,6 +3,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -29,6 +30,8 @@ type TableMeta struct {
 	Description string `json:"description,omitempty"`
 	// Model holds the value of the "model" field.
 	Model string `json:"model,omitempty"`
+	// Sources holds the value of the "sources" field.
+	Sources map[string]json.RawMessage `json:"sources,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the TableMetaQuery when eager-loading is set.
 	Edges        TableMetaEdges `json:"edges"`
@@ -69,6 +72,8 @@ func (*TableMeta) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
+		case tablemeta.FieldSources:
+			values[i] = new([]byte)
 		case tablemeta.FieldID:
 			values[i] = new(sql.NullInt64)
 		case tablemeta.FieldNanoid, tablemeta.FieldName, tablemeta.FieldDescription, tablemeta.FieldModel:
@@ -131,6 +136,14 @@ func (tm *TableMeta) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field model", values[i])
 			} else if value.Valid {
 				tm.Model = value.String
+			}
+		case tablemeta.FieldSources:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field sources", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &tm.Sources); err != nil {
+					return fmt.Errorf("unmarshal field sources: %w", err)
+				}
 			}
 		default:
 			tm.selectValues.Set(columns[i], values[i])
@@ -195,6 +208,9 @@ func (tm *TableMeta) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("model=")
 	builder.WriteString(tm.Model)
+	builder.WriteString(", ")
+	builder.WriteString("sources=")
+	builder.WriteString(fmt.Sprintf("%v", tm.Sources))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/tablemeta/tablemeta.go
+++ b/ent/tablemeta/tablemeta.go
@@ -26,6 +26,8 @@ const (
 	FieldDescription = "description"
 	// FieldModel holds the string denoting the model field in the database.
 	FieldModel = "model"
+	// FieldSources holds the string denoting the sources field in the database.
+	FieldSources = "sources"
 	// EdgeColumns holds the string denoting the columns edge name in mutations.
 	EdgeColumns = "columns"
 	// EdgeRows holds the string denoting the rows edge name in mutations.
@@ -57,6 +59,7 @@ var Columns = []string{
 	FieldName,
 	FieldDescription,
 	FieldModel,
+	FieldSources,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/ent/tablemeta/where.go
+++ b/ent/tablemeta/where.go
@@ -455,6 +455,16 @@ func ModelContainsFold(v string) predicate.TableMeta {
 	return predicate.TableMeta(sql.FieldContainsFold(FieldModel, v))
 }
 
+// SourcesIsNil applies the IsNil predicate on the "sources" field.
+func SourcesIsNil() predicate.TableMeta {
+	return predicate.TableMeta(sql.FieldIsNull(FieldSources))
+}
+
+// SourcesNotNil applies the NotNil predicate on the "sources" field.
+func SourcesNotNil() predicate.TableMeta {
+	return predicate.TableMeta(sql.FieldNotNull(FieldSources))
+}
+
 // HasColumns applies the HasEdge predicate on the "columns" edge.
 func HasColumns() predicate.TableMeta {
 	return predicate.TableMeta(func(s *sql.Selector) {

--- a/ent/tablemeta_create.go
+++ b/ent/tablemeta_create.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -97,6 +98,12 @@ func (tmc *TableMetaCreate) SetNillableModel(s *string) *TableMetaCreate {
 	if s != nil {
 		tmc.SetModel(*s)
 	}
+	return tmc
+}
+
+// SetSources sets the "sources" field.
+func (tmc *TableMetaCreate) SetSources(mm map[string]json.RawMessage) *TableMetaCreate {
+	tmc.mutation.SetSources(mm)
 	return tmc
 }
 
@@ -249,6 +256,10 @@ func (tmc *TableMetaCreate) createSpec() (*TableMeta, *sqlgraph.CreateSpec) {
 	if value, ok := tmc.mutation.Model(); ok {
 		_spec.SetField(tablemeta.FieldModel, field.TypeString, value)
 		_node.Model = value
+	}
+	if value, ok := tmc.mutation.Sources(); ok {
+		_spec.SetField(tablemeta.FieldSources, field.TypeJSON, value)
+		_node.Sources = value
 	}
 	if nodes := tmc.mutation.ColumnsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -406,6 +417,24 @@ func (u *TableMetaUpsert) UpdateModel() *TableMetaUpsert {
 	return u
 }
 
+// SetSources sets the "sources" field.
+func (u *TableMetaUpsert) SetSources(v map[string]json.RawMessage) *TableMetaUpsert {
+	u.Set(tablemeta.FieldSources, v)
+	return u
+}
+
+// UpdateSources sets the "sources" field to the value that was provided on create.
+func (u *TableMetaUpsert) UpdateSources() *TableMetaUpsert {
+	u.SetExcluded(tablemeta.FieldSources)
+	return u
+}
+
+// ClearSources clears the value of the "sources" field.
+func (u *TableMetaUpsert) ClearSources() *TableMetaUpsert {
+	u.SetNull(tablemeta.FieldSources)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -532,6 +561,27 @@ func (u *TableMetaUpsertOne) SetModel(v string) *TableMetaUpsertOne {
 func (u *TableMetaUpsertOne) UpdateModel() *TableMetaUpsertOne {
 	return u.Update(func(s *TableMetaUpsert) {
 		s.UpdateModel()
+	})
+}
+
+// SetSources sets the "sources" field.
+func (u *TableMetaUpsertOne) SetSources(v map[string]json.RawMessage) *TableMetaUpsertOne {
+	return u.Update(func(s *TableMetaUpsert) {
+		s.SetSources(v)
+	})
+}
+
+// UpdateSources sets the "sources" field to the value that was provided on create.
+func (u *TableMetaUpsertOne) UpdateSources() *TableMetaUpsertOne {
+	return u.Update(func(s *TableMetaUpsert) {
+		s.UpdateSources()
+	})
+}
+
+// ClearSources clears the value of the "sources" field.
+func (u *TableMetaUpsertOne) ClearSources() *TableMetaUpsertOne {
+	return u.Update(func(s *TableMetaUpsert) {
+		s.ClearSources()
 	})
 }
 
@@ -827,6 +877,27 @@ func (u *TableMetaUpsertBulk) SetModel(v string) *TableMetaUpsertBulk {
 func (u *TableMetaUpsertBulk) UpdateModel() *TableMetaUpsertBulk {
 	return u.Update(func(s *TableMetaUpsert) {
 		s.UpdateModel()
+	})
+}
+
+// SetSources sets the "sources" field.
+func (u *TableMetaUpsertBulk) SetSources(v map[string]json.RawMessage) *TableMetaUpsertBulk {
+	return u.Update(func(s *TableMetaUpsert) {
+		s.SetSources(v)
+	})
+}
+
+// UpdateSources sets the "sources" field to the value that was provided on create.
+func (u *TableMetaUpsertBulk) UpdateSources() *TableMetaUpsertBulk {
+	return u.Update(func(s *TableMetaUpsert) {
+		s.UpdateSources()
+	})
+}
+
+// ClearSources clears the value of the "sources" field.
+func (u *TableMetaUpsertBulk) ClearSources() *TableMetaUpsertBulk {
+	return u.Update(func(s *TableMetaUpsert) {
+		s.ClearSources()
 	})
 }
 

--- a/ent/tablemeta_update.go
+++ b/ent/tablemeta_update.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -102,6 +103,18 @@ func (tmu *TableMetaUpdate) SetNillableModel(s *string) *TableMetaUpdate {
 	if s != nil {
 		tmu.SetModel(*s)
 	}
+	return tmu
+}
+
+// SetSources sets the "sources" field.
+func (tmu *TableMetaUpdate) SetSources(mm map[string]json.RawMessage) *TableMetaUpdate {
+	tmu.mutation.SetSources(mm)
+	return tmu
+}
+
+// ClearSources clears the value of the "sources" field.
+func (tmu *TableMetaUpdate) ClearSources() *TableMetaUpdate {
+	tmu.mutation.ClearSources()
 	return tmu
 }
 
@@ -269,6 +282,12 @@ func (tmu *TableMetaUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := tmu.mutation.Model(); ok {
 		_spec.SetField(tablemeta.FieldModel, field.TypeString, value)
+	}
+	if value, ok := tmu.mutation.Sources(); ok {
+		_spec.SetField(tablemeta.FieldSources, field.TypeJSON, value)
+	}
+	if tmu.mutation.SourcesCleared() {
+		_spec.ClearField(tablemeta.FieldSources, field.TypeJSON)
 	}
 	if tmu.mutation.ColumnsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -453,6 +472,18 @@ func (tmuo *TableMetaUpdateOne) SetNillableModel(s *string) *TableMetaUpdateOne 
 	if s != nil {
 		tmuo.SetModel(*s)
 	}
+	return tmuo
+}
+
+// SetSources sets the "sources" field.
+func (tmuo *TableMetaUpdateOne) SetSources(mm map[string]json.RawMessage) *TableMetaUpdateOne {
+	tmuo.mutation.SetSources(mm)
+	return tmuo
+}
+
+// ClearSources clears the value of the "sources" field.
+func (tmuo *TableMetaUpdateOne) ClearSources() *TableMetaUpdateOne {
+	tmuo.mutation.ClearSources()
 	return tmuo
 }
 
@@ -650,6 +681,12 @@ func (tmuo *TableMetaUpdateOne) sqlSave(ctx context.Context) (_node *TableMeta, 
 	}
 	if value, ok := tmuo.mutation.Model(); ok {
 		_spec.SetField(tablemeta.FieldModel, field.TypeString, value)
+	}
+	if value, ok := tmuo.mutation.Sources(); ok {
+		_spec.SetField(tablemeta.FieldSources, field.TypeJSON, value)
+	}
+	if tmuo.mutation.SourcesCleared() {
+		_spec.ClearField(tablemeta.FieldSources, field.TypeJSON)
 	}
 	if tmuo.mutation.ColumnsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,9 @@ All examples are generated using gemini-2.0-flash-001 with a tempature of 0.6.
 
 - **recipes_cuisine_meal**
   Building on the `recipes_cuisine` example, this variation adds a "meal" column, where the value is selected from 6 meal options, creating more diversity in the results.
+  
+- **recipes_cuisine_meal_ingredients**
+  Building on the `recipes_cuisine_meal` example, this variation adds two must-have-ingredient column, where the value is selected from 50 AI generated ingredients, creating even more diversity in the results. (But it doesn't seem very creative, maybe try a different model later.)
 
 - **recipes_by_country**
   This example demonstrates how to repeat column values. The generated table will include 6 recipes for each country: 2 Breakfast recipes, 2 Lunch recipes, and 2 Dinner recipes.

--- a/examples/recipes_by_country/recipes.csv
+++ b/examples/recipes_by_country/recipes.csv
@@ -1,49 +1,49 @@
 Name,Ingredients,Cooking Time,Country,Meals
-Scallion Pancake,"[""All-purpose flour"",""Salt"",""Hot water"",""Cold water"",""Scallions"",""Vegetable oil"",""Sesame oil""]",30,China,Breakfast
-Congee,"[""Rice"",""Water"",""Salt"",""Ginger"",""Scallions"",""Soy sauce"",""Sesame oil""]",45,China,Breakfast
-Dumplings,"[""Ground pork"",""Napa cabbage"",""Ginger"",""Soy sauce"",""Sesame oil"",""Dumpling wrappers""]",60,China,Lunch
-Noodles with Sesame Sauce,"[""Noodles"",""Sesame paste"",""Soy sauce"",""Vinegar"",""Sugar"",""Chili oil"",""Cucumber""]",20,China,Lunch
-Mapo Tofu,"[""Tofu"",""Ground pork"",""Doubanjiang"",""Soy sauce"",""Sugar"",""Cornstarch"",""Sichuan peppercorns"",""Scallions""]",35,China,Dinner
-Kung Pao Chicken,"[""Chicken"",""Peanuts"",""Dried chili peppers"",""Sichuan peppercorns"",""Soy sauce"",""Vinegar"",""Sugar"",""Cornstarch"",""Scallions"",""Ginger"",""Garlic""]",40,China,Dinner
-Sushi,"[""Rice"",""Seaweed"",""Fish"",""Vegetables""]",30,Japan,Breakfast
-Miso Soup,"[""Tofu"",""Seaweed"",""Green onion"",""Miso paste""]",15,Japan,Breakfast
-Ramen,"[""Noodles"",""Broth"",""Pork"",""Egg"",""Seaweed""]",45,Japan,Lunch
-Tempura,"[""Shrimp"",""Vegetables"",""Flour"",""Egg""]",35,Japan,Lunch
-Yakitori,"[""Chicken"",""Soy sauce"",""Mirin"",""Sugar""]",25,Japan,Dinner
-Okonomiyaki,"[""Flour"",""Egg"",""Cabbage"",""Pork belly"",""Okonomiyaki sauce""]",40,Japan,Dinner
-Full English Breakfast,"[""Eggs"",""Bacon"",""Toast"",""Sausage""]",20,England,Breakfast
-Vegetarian Breakfast,"[""Eggs"",""Mushrooms"",""Tomatoes"",""Toast""]",15,England,Breakfast
-Ploughman's Lunch,"[""Cheddar Cheese"",""Pickles"",""Bread"",""Apple""]",5,England,Lunch
-Bangers and Mash,"[""Sausage"",""Mashed Potatoes"",""Gravy"",""Peas""]",35,England,Lunch
-Fish and Chips,"[""Cod Fillets"",""Potatoes"",""Peas"",""Tartar Sauce""]",25,England,Dinner
-Beef Wellington,"[""Beef"",""Carrots"",""Potatoes"",""Gravy""]",120,England,Dinner
-Full English,"[""Eggs"",""Bacon"",""Sausage"",""Tomatoes"",""Mushrooms"",""Toast""]",30,Thailand,Breakfast
-Scotch Breakfast,"[""Eggs"",""Bacon"",""Sausage"",""Black Pudding"",""Tattie Scone"",""Toast""]",35,Thailand,Breakfast
-Sunday Roast,"[""Roast Beef"",""Roast Potatoes"",""Yorkshire Pudding"",""Vegetables"",""Gravy""]",120,Thailand,Lunch
-Shepherd's Pie,"[""Ground Lamb"",""Vegetables"",""Mashed Potatoes""]",75,Thailand,Lunch
-Chicken Tikka Masala,"[""Chicken"",""Yogurt"",""Tomatoes"",""Cream"",""Spices""]",45,Thailand,Dinner
-Chicken Pot Pie,"[""Chicken"",""Vegetables"",""Pie Crust""]",60,Thailand,Dinner
-Croque Monsieur,"[""Bread"",""Ham"",""Cheese"",""Butter""]",30,France,Breakfast
-French Toast,"[""Bread"",""Eggs"",""Milk"",""Sugar"",""Cinnamon""]",25,France,Breakfast
-Quiche Lorraine,"[""Eggs"",""Cream"",""Bacon"",""Cheese"",""Pastry""]",45,France,Lunch
-Salad Niçoise,"[""Lettuce"",""Tomatoes"",""Eggs"",""Tuna"",""Olives"",""Anchovies""]",60,France,Lunch
-Boeuf Bourguignon,"[""Beef"",""Red Wine"",""Mushrooms"",""Onions"",""Carrots"",""Bacon""]",90,France,Dinner
-Coq au Vin,"[""Chicken"",""Red Wine"",""Mushrooms"",""Onions"",""Bacon"",""Brandy""]",120,France,Dinner
-Tiramisu,"[""Ladyfingers"",""Espresso"",""Mascarpone cheese"",""Eggs"",""Sugar"",""Cocoa powder""]",30,Italy,Breakfast
-Panna Cotta,"[""Cream"",""Sugar"",""Gelatin"",""Vanilla extract""]",20,Italy,Breakfast
-Bruschetta,"[""Bread"",""Tomatoes"",""Garlic"",""Olive oil"",""Basil""]",15,Italy,Lunch
-Caprese Salad,"[""Tomatoes"",""Mozzarella cheese"",""Basil"",""Olive oil"",""Balsamic glaze""]",10,Italy,Lunch
-Osso Buco,"[""Veal shanks"",""Vegetables"",""White wine"",""Broth"",""Gremolata""]",180,Italy,Dinner
-Risotto Milanese,"[""Arborio rice"",""Saffron"",""Parmesan cheese"",""Butter"",""Onion"",""White wine"",""Broth""]",45,Italy,Dinner
-Churros,"[""Water"",""Flour"",""Salt"",""Oil"",""Sugar"",""Cinnamon""]",30,Spain,Breakfast
-Pan con Tomate,"[""Bread"",""Tomato"",""Olive Oil"",""Salt""]",10,Spain,Breakfast
-Paella,"[""Rice"",""Saffron"",""Chicken"",""Seafood"",""Vegetables"",""Olive Oil""]",60,Spain,Lunch
-Gazpacho,"[""Tomatoes"",""Cucumber"",""Bell Pepper"",""Onion"",""Garlic"",""Olive Oil"",""Vinegar""]",20,Spain,Lunch
-Gambas al Ajillo,"[""Shrimp"",""Garlic"",""Olive Oil"",""Chili Flakes"",""Parsley""]",15,Spain,Dinner
-Tortilla Española,"[""Potatoes"",""Eggs"",""Onion"",""Olive Oil"",""Salt""]",45,Spain,Dinner
-Patatas Bravas,"[""Potatoes"",""Olive oil"",""Smoked paprika"",""Garlic"",""Tomato paste"",""Cayenne pepper"",""Vinegar""]",30,India,Breakfast
-Croquetas,"[""Milk"",""Flour"",""Butter"",""Ham"",""Breadcrumbs"",""Egg""]",45,India,Breakfast
-Pimientos de Padrón,"[""Padrón peppers"",""Olive oil"",""Sea salt""]",15,India,Lunch
-Pulpo a la Gallega,"[""Octopus"",""Potatoes"",""Olive oil"",""Smoked paprika"",""Sea salt""]",60,India,Lunch
-Chorizo al Vino,"[""Chorizo"",""Red wine"",""Olive oil"",""Garlic"",""Bay leaf""]",25,India,Dinner
-Queso Manchego,"[""Manchego cheese"",""Olive oil"",""Rosemary""]",10,India,Dinner
+Chinese Pancakes,"[""Flour"",""Water"",""Salt"",""Scallions"",""Oil""]",15,China,Breakfast
+Congee,"[""Rice"",""Water"",""Salt"",""Ginger"",""Soy Sauce""]",20,China,Breakfast
+Dumplings,"[""Ground Pork"",""Cabbage"",""Ginger"",""Soy Sauce"",""Dumpling Wrappers""]",25,China,Lunch
+Noodles with Sesame Sauce,"[""Noodles"",""Sesame Paste"",""Soy Sauce"",""Vinegar"",""Garlic""]",30,China,Lunch
+Mapo Tofu,"[""Tofu"",""Ground Pork"",""Doubanjiang"",""Soy Sauce"",""Chili Oil""]",40,China,Dinner
+Kung Pao Chicken,"[""Chicken"",""Peanuts"",""Dried Chili Peppers"",""Soy Sauce"",""Vinegar""]",45,China,Dinner
+Tamago Kake Gohan,"[""Rice"",""Egg"",""Soy Sauce"",""Green Onion""]",15,Japan,Breakfast
+Miso Soup,"[""Miso Paste"",""Tofu"",""Seaweed"",""Green Onion""]",20,Japan,Breakfast
+Tempura Udon,"[""Udon Noodles"",""Dashi Broth"",""Soy Sauce"",""Tempura""]",30,Japan,Lunch
+Zaru Soba,"[""Soba Noodles"",""Dashi Broth"",""Soy Sauce"",""Green Onion"",""Wasabi""]",25,Japan,Lunch
+Salmon Nigiri,"[""Rice"",""Salmon"",""Nori Seaweed"",""Soy Sauce"",""Wasabi""]",45,Japan,Dinner
+Chirashi Sushi,"[""Rice"",""Various Fish"",""Nori Seaweed"",""Soy Sauce"",""Wasabi""]",60,Japan,Dinner
+Full English Breakfast,"[""Eggs"",""Bacon"",""Toast"",""Butter""]",15,England,Breakfast
+Sausage and Egg Breakfast,"[""Sausages"",""Eggs"",""Toast"",""Mushrooms""]",20,England,Breakfast
+Cheese and Pickle Sandwich,"[""Cheddar Cheese"",""Pickles"",""Bread"",""Butter""]",10,England,Lunch
+Chicken Sandwich,"[""Chicken"",""Lettuce"",""Mayonnaise"",""Bread""]",10,England,Lunch
+Beef Stew,"[""Beef"",""Potatoes"",""Carrots"",""Gravy""]",120,England,Dinner
+Fish and Chips,"[""Fish"",""Chips"",""Salt"",""Vinegar""]",30,England,Dinner
+Thai Fried Rice,"[""Rice"",""Egg"",""Pork"",""Vegetables""]",20,Thailand,Breakfast
+Mango Sticky Rice,"[""Sticky Rice"",""Mango"",""Coconut Milk""]",30,Thailand,Breakfast
+Pad See Ew,"[""Noodles"",""Chicken"",""Vegetables"",""Soy Sauce""]",25,Thailand,Lunch
+Pad Thai,"[""Rice Noodles"",""Shrimp"",""Tofu"",""Peanuts"",""Bean Sprouts""]",30,Thailand,Lunch
+Green Curry,"[""Green Curry Paste"",""Coconut Milk"",""Chicken"",""Eggplant"",""Bamboo Shoots""]",35,Thailand,Dinner
+Massaman Curry,"[""Red Curry Paste"",""Coconut Milk"",""Beef"",""Potatoes"",""Peanuts""]",40,Thailand,Dinner
+Crème brûlée,"[""Heavy cream"",""Vanilla bean"",""Egg yolks"",""Sugar""]",60,France,Breakfast
+Croissant,"[""Flour"",""Yeast"",""Butter"",""Sugar"",""Milk""]",45,France,Breakfast
+Quiche Lorraine,"[""Pâte Brisée"",""Eggs"",""Cream"",""Bacon"",""Gruyère cheese""]",75,France,Lunch
+Salad Niçoise,"[""Lettuce"",""Tomatoes"",""Eggs"",""Olives"",""Anchovies"",""Tuna"",""Green beans""]",20,France,Lunch
+Coq au vin,"[""Chicken"",""Red wine"",""Mushrooms"",""Bacon"",""Onions"",""Carrots""]",120,France,Dinner
+Soupe à l'oignon,"[""Onions"",""Beef broth"",""Bread"",""Gruyère cheese"",""Butter""]",90,France,Dinner
+Frittata,"[""Eggs"",""Milk"",""Flour"",""Sugar""]",20,Italy,Breakfast
+Bruschetta,"[""Bread"",""Tomato"",""Mozzarella"",""Basil""]",10,Italy,Breakfast
+Pasta al Pesto,"[""Pasta"",""Pesto"",""Pine nuts"",""Parmesan""]",15,Italy,Lunch
+Caprese Salad,"[""Tomatoes"",""Mozzarella"",""Basil"",""Olive Oil""]",25,Italy,Lunch
+Risotto alla Milanese,"[""Rice"",""Saffron"",""Parmesan"",""Butter""]",30,Italy,Dinner
+Pizza Margherita,"[""Dough"",""Tomato Sauce"",""Mozzarella"",""Various Toppings""]",25,Italy,Dinner
+Pan con Tomate,"[""Bread"",""Tomato"",""Olive Oil"",""Garlic""]",10,Spain,Breakfast
+Tortilla Española,"[""Eggs"",""Potatoes"",""Onion"",""Olive Oil""]",40,Spain,Breakfast
+Espinacas con Garbanzos,"[""Chickpeas"",""Spinach"",""Onion"",""Garlic"",""Spices""]",35,Spain,Lunch
+Arroz con Pollo,"[""Rice"",""Chicken"",""Vegetables"",""Saffron"",""Broth""]",50,Spain,Lunch
+Paella,"[""Seafood"",""Rice"",""Vegetables"",""Saffron"",""Broth""]",60,Spain,Dinner
+Patatas a la Riojana,"[""Potatoes"",""Chorizo"",""Paprika"",""Olive Oil""]",45,Spain,Dinner
+Egg Halwa,"[""Eggs"",""Milk"",""Sugar"",""Cardamom""]",25,India,Breakfast
+Suji Halwa,"[""Semolina"",""Sugar"",""Ghee"",""Cashews"",""Raisins""]",30,India,Breakfast
+Vegetable Khichdi,"[""Rice"",""Lentils"",""Vegetables"",""Spices""]",40,India,Lunch
+Chole Bhature,"[""Chickpeas"",""Tomatoes"",""Onions"",""Spices""]",35,India,Lunch
+Chicken Biryani,"[""Chicken"",""Rice"",""Yogurt"",""Spices""]",50,India,Dinner
+Dal Palak,"[""Lentils"",""Spinach"",""Tomatoes"",""Spices""]",45,India,Dinner

--- a/examples/recipes_by_country/recipes.json
+++ b/examples/recipes_by_country/recipes.json
@@ -14,14 +14,12 @@
         "Italy",
         "Spain",
         "India"
-      ],
-      "repeat": 6
+      ]
     },
     {
       "name": "meals",
       "type": "list",
-      "options": ["Breakfast", "Lunch", "Dinner"],
-      "repeat": 2
+      "options": ["Breakfast", "Lunch", "Dinner"]
     }
   ],
   "columns": [
@@ -49,14 +47,16 @@
       "description": "The country of origin of the recipe.",
       "type": "string",
       "fill_mode": "pick",
-      "source": "country"
+      "source": "country",
+      "repeat": 6
     },
     {
       "name": "Meals",
       "description": "The meal type (e.g., Breakfast, Lunch, Dinner) for which the recipe is intended.",
       "type": "string",
       "fill_mode": "pick",
-      "source": "meals"
+      "source": "meals",
+      "repeat": 2
     }
   ]
 }

--- a/examples/recipes_cuisine/recipes.csv
+++ b/examples/recipes_cuisine/recipes.csv
@@ -1,101 +1,101 @@
 Name,Ingredients,Cooking Time,Cuisine,Difficulty Level
-Stir-Fried Noodles,"[""Soy sauce"",""Ginger"",""Garlic"",""Noodles"",""Vegetables""]",30,Chinese,3
-Sushi Rolls,"[""Rice"",""Seaweed"",""Fish"",""Avocado"",""Soy sauce""]",20,Japanese,4
-Hummus,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil""]",45,Lebanese,2
-Greek Salad,"[""Tomatoes"",""Cucumbers"",""Olives"",""Feta cheese"",""Olive oil""]",60,Mediterranean,1
-Classic Burger,"[""Ground beef"",""Lettuce"",""Tomato"",""Cheese"",""Buns""]",40,American,3
-Apple Tart,"[""Flour"",""Butter"",""Eggs"",""Sugar"",""Apples""]",75,French,4
-Doro Wat,"[""Berbere spice"",""Chicken"",""Onions"",""Tomatoes"",""Injera bread""]",90,Ethiopian,5
-Tacos,"[""Tortillas"",""Ground beef"",""Cheese"",""Salsa"",""Sour cream""]",35,Mexican,2
-Spaghetti Bolognese,"[""Pasta"",""Tomato sauce"",""Ground beef"",""Onions"",""Garlic""]",50,Italian,3
-Chicken Tagine,"[""Chicken"",""Olives"",""Lemon"",""Onions"",""Spices""]",65,Moroccan,4
-Paella,"[""Rice"",""Saffron"",""Seafood"",""Chicken"",""Vegetables""]",45,Spanish,4
-Bibimbap,"[""Rice"",""Vegetables"",""Beef"",""Egg"",""Gochujang""]",40,Korean,3
-Dal Makhani,"[""Rice"",""Lentils"",""Spices"",""Vegetables"",""Ghee""]",55,Indian,3
-Ceviche,"[""Fish"",""Lime juice"",""Onions"",""Chili peppers"",""Cilantro""]",70,Peruvian,2
-Feijoada,"[""Black beans"",""Pork"",""Onions"",""Garlic"",""Rice""]",80,Brazilian,4
-Bratkartoffeln,"[""Potatoes"",""Sausage"",""Sauerkraut"",""Onions"",""Mustard""]",95,German,3
-Pho,"[""Rice noodles"",""Beef"",""Bean sprouts"",""Herbs"",""Fish sauce""]",30,Vietnamese,3
-Horiatiki Salad,"[""Cucumbers"",""Tomatoes"",""Feta cheese"",""Olives"",""Olive oil""]",40,Greek,1
-Pad Thai,"[""Rice noodles"",""Shrimp"",""Tofu"",""Peanuts"",""Tamarind sauce""]",25,Thai,2
-Karniyarik,"[""Eggplant"",""Ground beef"",""Tomatoes"",""Onions"",""Spices""]",50,Turkish,3
-Paella,"[""Rice"",""Seafood"",""Saffron"",""Chicken"",""Vegetables""]",60,Spanish,4
-Ramen,"[""Noodles"",""Broth"",""Pork"",""Egg"",""Seaweed""]",45,Japanese,3
-Injera with Wat,"[""Injera bread"",""Stew"",""Meat"",""Vegetables"",""Spices""]",90,Ethiopian,4
-Hummus,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil""]",15,Lebanese,1
-Bibimbap,"[""Rice"",""Vegetables"",""Meat"",""Egg"",""Gochujang""]",30,Korean,2
-Tacos,"[""Tortillas"",""Meat"",""Salsa"",""Onions"",""Cilantro""]",20,Mexican,2
-Pasta Carbonara,"[""Pasta"",""Eggs"",""Pancetta"",""Parmesan cheese"",""Black pepper""]",25,Italian,2
-Tom Yum Soup,"[""Lemongrass"",""Galangal"",""Lime leaves"",""Chili peppers"",""Shrimp""]",35,Thai,3
-Feijoada,"[""Black beans"",""Pork"",""Beef"",""Sausage"",""Rice""]",120,Brazilian,4
-Banh Mi,"[""Baguette"",""Pate"",""Meat"",""Pickled vegetables"",""Cilantro""]",15,Vietnamese,2
-Hamburger,"[""Bun"",""Beef patty"",""Lettuce"",""Tomato"",""Cheese""]",20,American,1
-Dumplings,"[""Dough"",""Pork"",""Cabbage"",""Ginger"",""Soy sauce""]",40,Chinese,3
-Moussaka,"[""Eggplant"",""Ground meat"",""Potatoes"",""Bechamel sauce"",""Cheese""]",75,Greek,4
-Tabbouleh,"[""Bulgur"",""Parsley"",""Mint"",""Tomato"",""Cucumber""]",20,Mediterranean,1
-Schnitzel,"[""Pork"",""Breadcrumbs"",""Egg"",""Flour"",""Lemon""]",30,German,2
-Crêpes,"[""Flour"",""Eggs"",""Milk"",""Butter"",""Sugar""]",30,French,2
-Ceviche,"[""Fish"",""Lime juice"",""Onion"",""Cilantro"",""Chili""]",15,Peruvian,2
-Dolma,"[""Grape leaves"",""Rice"",""Meat"",""Spices"",""Onion""]",60,Turkish,3
-Tagine,"[""Meat"",""Vegetables"",""Spices"",""Dried fruit"",""Olive oil""]",90,Moroccan,4
-Butter Chicken,"[""Chicken"",""Tomato sauce"",""Butter"",""Cream"",""Spices""]",45,Indian,3
-Baklava,"[""phyllo dough"",""butter"",""walnuts"",""sugar"",""lemon juice"",""honey""]",60,Turkish,3
-Kung Pao Chicken,"[""chicken"",""peanuts"",""dried chili peppers"",""soy sauce"",""vinegar"",""sugar"",""cornstarch""]",30,Chinese,3
-Apple Pie,"[""apples"",""flour"",""butter"",""sugar"",""cinnamon""]",75,American,2
-Injera,"[""teff flour"",""water"",""yeast""]",45,Ethiopian,3
-Moussaka,"[""eggplant"",""potatoes"",""ground meat"",""béchamel sauce"",""cheese""]",90,Mediterranean,4
-Hummus,"[""chickpeas"",""tahini"",""lemon juice"",""garlic"",""olive oil""]",15,Lebanese,1
-Tacos,"[""tortillas"",""ground beef"",""lettuce"",""tomatoes"",""cheese"",""salsa""]",25,Mexican,2
-Couscous,"[""couscous"",""vegetables"",""meat"",""spices""]",40,Moroccan,2
-Kimchi,"[""napa cabbage"",""gochugaru"",""garlic"",""ginger"",""fish sauce"",""salt""]",1440,Korean,3
-Sauerbraten,"[""beef"",""vinegar"",""water"",""onions"",""carrots"",""celery"",""gingerbread"",""raisins""]",180,German,4
-Paella,"[""rice"",""saffron"",""seafood"",""chicken"",""vegetables""]",60,Spanish,3
-Soupe à l'oignon,"[""onions"",""beef broth"",""bread"",""cheese""]",50,French,3
-Biryani,"[""rice"",""meat"",""spices"",""yogurt""]",70,Indian,4
-Spanakopita,"[""spinach"",""feta cheese"",""phyllo dough"",""eggs"",""butter""]",60,Greek,3
-Lomo Saltado,"[""beef"",""onions"",""tomatoes"",""soy sauce"",""vinegar"",""french fries"",""rice""]",35,Peruvian,2
-Sushi,"[""rice"",""seaweed"",""fish"",""vegetables""]",40,Japanese,3
-Pizza,"[""dough"",""tomato sauce"",""cheese"",""toppings""]",30,Italian,2
-Feijoada,"[""black beans"",""pork"",""beef"",""sausage"",""rice"",""oranges"",""collard greens""]",120,Brazilian,4
-Pad Thai,"[""rice noodles"",""shrimp"",""tofu"",""peanuts"",""bean sprouts"",""egg"",""tamarind paste""]",30,Thai,3
-Pho,"[""beef broth"",""rice noodles"",""beef"",""herbs"",""spices""]",90,Vietnamese,3
-Ratatouille,"[""Eggplant"",""Zucchini"",""Bell peppers"",""Tomatoes"",""Onion"",""Garlic"",""Herbs"",""Olive oil""]",60,French,3
-Banh Mi,"[""Baguette"",""Pork"",""Pickled vegetables"",""Cilantro"",""Jalapeno"",""Mayonnaise"",""Soy sauce""]",45,Vietnamese,2
-Moussaka,"[""Eggplant"",""Potatoes"",""Ground meat"",""Tomato sauce"",""Béchamel sauce"",""Cheese"",""Onion"",""Garlic""]",50,Greek,4
-Pasta Carbonara,"[""Pasta"",""Eggs"",""Pancetta"",""Parmesan cheese"",""Black pepper"",""Olive oil""]",35,Italian,2
-Falafel,"[""Chickpeas"",""Onion"",""Garlic"",""Parsley"",""Cilantro"",""Spices"",""Tahini"",""Lemon juice""]",40,Mediterranean,3
-Tacos,"[""Tortillas"",""Ground beef"",""Lettuce"",""Tomato"",""Cheese"",""Salsa"",""Sour cream""]",30,Mexican,2
-Ramen,"[""Noodles"",""Broth"",""Pork belly"",""Egg"",""Seaweed"",""Green onion""]",25,Japanese,4
-Kung Pao Chicken,"[""Chicken"",""Peanuts"",""Vegetables"",""Soy sauce"",""Vinegar"",""Sugar"",""Chili peppers""]",45,Chinese,3
-Moqueca,"[""Fish"",""Shrimp"",""Coconut milk"",""Tomatoes"",""Onions"",""Bell peppers"",""Cilantro"",""Palm oil""]",90,Brazilian,4
-Kebab,"[""Lamb"",""Beef"",""Chicken"",""Vegetables"",""Yogurt"",""Spices"",""Olive oil""]",55,Turkish,3
-Hummus,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil"",""Paprika""]",40,Lebanese,1
-Bibimbap,"[""Rice"",""Vegetables"",""Meat"",""Egg"",""Gochujang""]",70,Korean,3
-Butter Chicken,"[""Chicken"",""Tomato sauce"",""Butter"",""Cream"",""Spices""]",60,Indian,4
-Paella,"[""Rice"",""Seafood"",""Chicken"",""Rabbit"",""Saffron"",""Vegetables""]",50,Spanish,4
-Injera with Wat,"[""Injera"",""Meat stew"",""Vegetable stew"",""Spices""]",75,Ethiopian,3
-Cheeseburger,"[""Bun"",""Beef patty"",""Cheese"",""Lettuce"",""Tomato"",""Onion"",""Pickles"",""Sauce""]",40,American,2
-Tom Yum Soup,"[""Broth"",""Shrimp"",""Lemongrass"",""Galangal"",""Lime leaves"",""Chili peppers"",""Mushrooms""]",30,Thai,3
-Ceviche,"[""Fish"",""Lime juice"",""Onion"",""Cilantro"",""Chili peppers""]",45,Peruvian,2
-Sauerbraten,"[""Beef"",""Vinegar"",""Spices"",""Vegetables"",""Gingerbread""]",80,German,4
-Tagine,"[""Meat"",""Vegetables"",""Dried fruit"",""Spices"",""Olive oil""]",55,Moroccan,3
-Lomo Saltado,"[""Beef steak"",""Soy sauce"",""Vinegar"",""Potatoes"",""Onions"",""Tomatoes""]",30,Peruvian,3
-Rouladen,"[""Beef"",""Bacon"",""Onions"",""Pickles"",""Mustard"",""Red wine""]",120,German,4
-Feijoada,"[""Black beans"",""Pork"",""Beef"",""Sausage"",""Rice"",""Collard greens"",""Orange slices""]",180,Brazilian,4
-Peking Duck,"[""Duck"",""Maltose syrup"",""Scallions"",""Cucumbers"",""Pancakes"",""Hoisin sauce""]",150,Chinese,5
-Butter Chicken,"[""Chicken"",""Tomato sauce"",""Butter"",""Cream"",""Garam masala"",""Ginger"",""Garlic""]",45,Indian,3
-Coq au Vin,"[""Chicken"",""Red wine"",""Mushrooms"",""Bacon"",""Onions"",""Brandy""]",90,French,4
-Pho,"[""Beef broth"",""Rice noodles"",""Beef"",""Bean sprouts"",""Lime"",""Cilantro"",""Basil""]",60,Vietnamese,3
-Pastilla,"[""Pigeon or Chicken"",""Almonds"",""Eggs"",""Onions"",""Cinnamon"",""Saffron"",""Phyllo dough""]",120,Moroccan,5
-Osso Buco,"[""Veal shanks"",""White wine"",""Vegetables"",""Broth"",""Gremolata""]",150,Italian,4
-Paella,"[""Rice"",""Saffron"",""Seafood"",""Chicken"",""Rabbit"",""Vegetables""]",75,Spanish,4
-Moussaka,"[""Eggplant"",""Ground meat"",""Potatoes"",""Bechamel sauce"",""Cheese""]",90,Mediterranean,4
-Kebab,"[""Lamb"",""Beef"",""Chicken"",""Vegetables"",""Spices""]",45,Turkish,2
-Bibimbap,"[""Rice"",""Vegetables"",""Meat"",""Egg"",""Gochujang""]",40,Korean,3
-Souvlaki,"[""Pork"",""Chicken"",""Lamb"",""Pita bread"",""Tzatziki sauce""]",30,Greek,2
-Injera with Wat,"[""Injera"",""Meat stew"",""Vegetable stew"",""Spices""]",60,Ethiopian,3
-Pad Thai,"[""Rice noodles"",""Shrimp"",""Tofu"",""Peanuts"",""Bean sprouts"",""Egg"",""Tamarind sauce""]",35,Thai,3
-Gumbo,"[""Okra"",""Shrimp"",""Sausage"",""Chicken"",""Rice"",""Spices""]",90,American,4
-Ramen,"[""Noodles"",""Broth"",""Pork"",""Egg"",""Seaweed"",""Scallions""]",45,Japanese,3
-Tacos,"[""Tortillas"",""Beef"",""Chicken"",""Pork"",""Salsa"",""Guacamole""]",25,Mexican,2
-Falafel,"[""Chickpeas"",""Herbs"",""Spices"",""Pita bread"",""Tahini sauce""]",30,Lebanese,2
+German Potato Salad,"[""Potatoes"",""Bacon"",""Onion"",""Vinegar"",""Mustard""]",45,German,3
+Chicken Tacos,"[""Chicken"",""Taco Shells"",""Salsa"",""Lettuce"",""Cheese""]",30,Mexican,2
+Turkish Delight,"[""Sugar"",""Cornstarch"",""Water"",""Rosewater"",""Lemon Juice""]",60,Turkish,3
+Greek Salad,"[""Tomatoes"",""Cucumbers"",""Onion"",""Feta Cheese"",""Olives"",""Olive Oil""]",25,Greek,2
+French Onion Soup,"[""Onions"",""Beef Broth"",""Bread"",""Cheese"",""Butter""]",90,French,4
+Hummus,"[""Chickpeas"",""Tahini"",""Lemon Juice"",""Garlic"",""Olive Oil""]",40,Lebanese,3
+Chicken Tagine,"[""Chicken"",""Onions"",""Apricots"",""Almonds"",""Spices""]",75,Moroccan,4
+Paella,"[""Rice"",""Seafood"",""Chicken"",""Vegetables"",""Saffron""]",35,Spanish,2
+Sushi Rolls,"[""Sushi Rice"",""Nori"",""Fish"",""Vegetables"",""Soy Sauce""]",50,Japanese,3
+Bibimbap,"[""Rice"",""Beef"",""Vegetables"",""Egg"",""Gochujang""]",65,Korean,4
+Pad Thai,"[""Rice noodles"",""Shrimp"",""Tofu"",""Bean sprouts"",""Peanuts"",""Lime"",""Fish sauce""]",30,Thai,3
+Spring Rolls,"[""Rice paper"",""Vermicelli noodles"",""Pork"",""Shrimp"",""Vegetables"",""Mint"",""Cilantro""]",25,Vietnamese,2
+Injera with Stew,"[""Injera bread"",""Stewed meat"",""Vegetables"",""Spices""]",90,Ethiopian,4
+Spaghetti Bolognese,"[""Pasta"",""Tomato sauce"",""Ground beef"",""Onions"",""Garlic"",""Herbs""]",45,Italian,2
+Lo Mein,"[""Noodles"",""Soy sauce"",""Sesame oil"",""Vegetables"",""Meat""]",35,Chinese,3
+Feijoada,"[""Black beans"",""Pork"",""Beef"",""Smoked sausage"",""Bay leaves""]",120,Brazilian,4
+Hamburger,"[""Ground beef"",""Buns"",""Lettuce"",""Tomato"",""Cheese"",""Pickles"",""Onion""]",20,American,1
+Chicken Pelau,"[""Chicken"",""Rice"",""Coconut milk"",""Peas"",""Carrots"",""Spices""]",50,Caribbean,3
+Falafel,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Olive oil"",""Garlic"",""Pita bread""]",40,Mediterranean,1
+Butter Chicken,"[""Chicken"",""Yogurt"",""Ginger"",""Garlic"",""Spices"",""Rice""]",60,Indian,4
+Crêpes,"[""Flour"",""Eggs"",""Milk"",""Sugar"",""Butter""]",30,French,2
+Karnıyarık,"[""Eggplant"",""Ground meat"",""Tomato sauce"",""Onion"",""Spices""]",75,Turkish,3
+Cheeseburger,"[""Ground beef"",""Buns"",""Lettuce"",""Tomato"",""Cheese""]",25,American,2
+Currywurst,"[""Sausage"",""Sauerkraut"",""Mustard"",""Buns""]",20,German,1
+Greek Salad,"[""Feta cheese"",""Tomatoes"",""Cucumber"",""Olives"",""Onion"",""Olive oil""]",15,Greek,1
+Curry Goat,"[""Goat meat"",""Curry powder"",""Coconut milk"",""Potatoes"",""Onion""]",90,Caribbean,4
+Paella,"[""Rice"",""Chicken"",""Saffron"",""Peas"",""Red bell pepper""]",60,Spanish,3
+Hummus,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil""]",10,Lebanese,1
+Sushi,"[""Rice"",""Seaweed"",""Salmon"",""Avocado"",""Soy sauce""]",45,Japanese,4
+Doro Wat,"[""Injera"",""Doro Wat sauce"",""Chicken"",""Berbere spice"",""Onion""]",120,Ethiopian,5
+Bibimbap,"[""Rice"",""Vegetables"",""Beef"",""Soy Sauce""]",45,Korean,3
+Feijoada,"[""Black Beans"",""Pork"",""Rice"",""Onion""]",60,Brazilian,2
+Spaghetti,"[""Pasta"",""Tomato Sauce"",""Basil"",""Mozzarella""]",30,Italian,2
+Falafel,"[""Chickpeas"",""Tahini"",""Lemon Juice"",""Olive Oil""]",50,Mediterranean,3
+Tacos,"[""Tortillas"",""Ground Beef"",""Cheese"",""Salsa""]",35,Mexican,2
+Pad Thai,"[""Rice Noodles"",""Shrimp"",""Tofu"",""Peanuts"",""Bean Sprouts""]",40,Thai,4
+Chow Mein,"[""Noodles"",""Chicken"",""Broccoli"",""Soy Sauce""]",25,Chinese,3
+Butter Chicken,"[""Chicken"",""Yogurt"",""Tomatoes"",""Spices""]",55,Indian,4
+Pho,"[""Rice Noodles"",""Beef"",""Bean Sprouts"",""Herbs""]",30,Vietnamese,3
+Tagine,"[""Chicken"",""Olives"",""Preserved Lemons"",""Spices""]",70,Moroccan,4
+Spaghetti Marinara,"[""Pasta"",""Tomato Sauce"",""Basil"",""Parmesan Cheese""]",30,Italian,2
+Tacos,"[""Tortillas"",""Ground Beef"",""Cheese"",""Salsa"",""Sour Cream""]",40,Mexican,3
+Bratwurst with Sauerkraut,"[""Sausage"",""Sauerkraut"",""Potatoes"",""Mustard""]",60,German,2
+Sushi Rolls,"[""Rice"",""Salmon"",""Avocado"",""Seaweed"",""Soy Sauce""]",25,Japanese,3
+Greek Salad,"[""Feta Cheese"",""Olives"",""Tomatoes"",""Cucumber"",""Olive Oil""]",15,Greek,1
+Couscous with Chicken,"[""Couscous"",""Chicken"",""Vegetables"",""Spices"",""Broth""]",90,Moroccan,4
+Rice and Peas,"[""Rice"",""Chicken"",""Beans"",""Coconut Milk"",""Spices""]",50,Caribbean,3
+Beef and Broccoli Stir-Fry,"[""Noodles"",""Beef"",""Broccoli"",""Soy Sauce"",""Ginger""]",35,Chinese,3
+Bun Bo Hue,"[""Noodles"",""Beef"",""Broth"",""Spices"",""Herbs""]",120,Vietnamese,4
+Lamb Kebab,"[""Lamb"",""Yogurt"",""Spices"",""Rice"",""Vegetables""]",75,Turkish,4
+Ethiopian Beef Stew (Key Wat),"[""Berbere spice blend"",""Onions"",""Garlic"",""Ginger"",""Beef cubes"",""Tomatoes"",""Vegetable oil""]",90,Ethiopian,3
+Pad See Ew,"[""Rice noodles"",""Chicken or vegetable broth"",""Tofu"",""Bean sprouts"",""Green onions"",""Cilantro"",""Lime"",""Chili flakes""]",30,Thai,2
+Galbi Jjim (Braised Short Ribs),"[""Short-grain rice"",""Beef short ribs"",""Soy sauce"",""Sesame oil"",""Garlic"",""Ginger"",""Gochujang (Korean chili paste)"",""Vegetables (carrots, daikon radish, spinach)""]",120,Korean,4
+Chicken Biryani,"[""Basmati rice"",""Chicken or lamb"",""Onions"",""Tomatoes"",""Yogurt"",""Ginger"",""Garlic"",""Garam masala"",""Turmeric"",""Chili powder""]",90,Indian,4
+Tabbouleh Salad,"[""Bulgur wheat"",""Parsley"",""Mint"",""Tomatoes"",""Onions"",""Cucumber"",""Lemon juice"",""Olive oil"",""Salt"",""Pepper""]",20,Lebanese,2
+Quiche Lorraine,"[""Eggs"",""Cream"",""Gruyere cheese"",""Bacon or ham"",""Onions"",""Nutmeg"",""Salt"",""Pepper"",""Puff pastry""]",60,French,3
+Paella,"[""Arborio rice"",""Saffron threads"",""Chicken or vegetable broth"",""Onion"",""White wine"",""Butter"",""Parmesan cheese""]",50,Spanish,3
+Chili Con Carne,"[""Ground beef"",""Onion"",""Garlic"",""Tomato sauce"",""Kidney beans"",""Chili powder"",""Cumin"",""Cheddar cheese"",""Sour cream""]",45,American,2
+Greek Salad,"[""Feta cheese"",""Cucumbers"",""Tomatoes"",""Onions"",""Olives"",""Olive oil"",""Oregano"",""Lemon juice""]",15,Mediterranean,1
+Feijoada,"[""Black beans"",""Rice"",""Beef"",""Onions"",""Garlic"",""Bell peppers"",""Cilantro"",""Lime juice"",""Spices""]",75,Brazilian,3
+Kimchi Fried Rice,"[""Kimchi"",""Rice"",""Gochujang"",""Egg"",""Vegetables""]",45,Korean,3
+Tacos,"[""Tortillas"",""Ground Beef"",""Lettuce"",""Tomato"",""Cheese"",""Salsa""]",30,Mexican,2
+Moqueca,"[""Fish"",""Shrimp"",""Coconut Milk"",""Tomatoes"",""Onions"",""Peppers""]",60,Brazilian,4
+Ramen,"[""Noodles"",""Broth"",""Pork Belly"",""Egg"",""Seaweed"",""Green Onions""]",50,Japanese,3
+Pho,"[""Rice Noodles"",""Beef"",""Broth"",""Bean Sprouts"",""Lime"",""Herbs""]",25,Vietnamese,2
+Spaghetti Carbonara,"[""Spaghetti"",""Eggs"",""Pancetta"",""Parmesan Cheese"",""Black Pepper""]",40,Italian,3
+Tzatziki,"[""Greek Yogurt"",""Cucumber"",""Garlic"",""Olive Oil"",""Lemon Juice"",""Dill""]",20,Greek,2
+Beef Bourguignon,"[""Beef"",""Red Wine"",""Mushrooms"",""Onions"",""Carrots"",""Bacon""]",75,French,4
+Kebab,"[""Lamb"",""Yogurt"",""Spices"",""Vegetables"",""Rice""]",40,Turkish,3
+Hummus,"[""Chickpeas"",""Tahini"",""Lemon Juice"",""Garlic"",""Olive Oil"",""Paprika""]",35,Mediterranean,2
+Jerk Chicken,"[""Chicken"",""Scotch bonnet peppers"",""Allspice"",""Thyme"",""Ginger"",""Garlic"",""Soy sauce""]",60,Caribbean,3
+Paella,"[""Rice"",""Saffron"",""Chicken"",""Seafood"",""Vegetables""]",45,Spanish,2
+Kung Pao Chicken,"[""Chicken"",""Peanuts"",""Chili peppers"",""Soy sauce"",""Vinegar"",""Sugar""]",30,Chinese,3
+Mac and Cheese,"[""Macaroni"",""Cheddar cheese"",""Milk"",""Butter"",""Flour""]",25,American,1
+Pad Thai,"[""Rice noodles"",""Tofu"",""Shrimp"",""Peanuts"",""Bean sprouts"",""Egg"",""Fish sauce""]",20,Thai,2
+Baba Ghanoush,"[""Eggplant"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil""]",15,Lebanese,1
+Doro Wat,"[""Chicken"",""Berbere spice"",""Onions"",""Garlic"",""Ginger"",""Hard-boiled eggs""]",40,Ethiopian,3
+Chicken Tikka Masala,"[""Chicken"",""Yogurt"",""Tomato sauce"",""Cream"",""Garam masala"",""Ginger"",""Garlic""]",35,Indian,2
+Tagine,"[""Meat"",""Vegetables"",""Dried fruit"",""Spices"",""Olive oil""]",50,Moroccan,4
+Sauerbraten,"[""Beef"",""Vinegar"",""Red wine"",""Gingerbread"",""Raisins""]",55,German,3
+Spaghetti al Pomodoro,"[""Pasta"",""Tomato Sauce"",""Basil"",""Olive Oil""]",30,Italian,2
+Bibimbap,"[""Rice"",""Beef"",""Vegetables"",""Gochujang""]",45,Korean,3
+Couscous with Vegetables,"[""Couscous"",""Vegetables"",""Spices"",""Chickpeas""]",60,Moroccan,3
+Chicken Biryani,"[""Chicken"",""Rice"",""Spices"",""Yogurt""]",50,Indian,4
+Arayes,"[""Pita Bread"",""Ground Meat"",""Vegetables"",""Tahini""]",40,Mediterranean,3
+Tacos,"[""Tortillas"",""Beef"",""Cheese"",""Salsa""]",25,Mexican,2
+Chow Mein,"[""Noodles"",""Chicken"",""Vegetables"",""Soy Sauce""]",35,Chinese,3
+Greek Salad,"[""Feta Cheese"",""Tomatoes"",""Cucumbers"",""Olives""]",20,Greek,1
+Rice and Peas,"[""Rice"",""Beans"",""Chicken"",""Spices""]",55,Caribbean,3
+Hamburger,"[""Burger Bun"",""Beef Patty"",""Lettuce"",""Tomato""]",20,American,2
+Ethiopian Beef Stew,"[""Berbere"",""Onion"",""Garlic"",""Ginger"",""Beef"",""Tomatoes"",""Butter""]",90,Ethiopian,3
+German Pork Roast,"[""Pork"",""Sauerkraut"",""Potatoes"",""Onion"",""Caraway Seeds"",""Juniper Berries"",""Broth""]",120,German,4
+Salmon Sushi,"[""Rice"",""Salmon"",""Seaweed"",""Soy Sauce"",""Wasabi"",""Ginger"",""Avocado""]",30,Japanese,2
+Feijoada,"[""Black Beans"",""Rice"",""Pork"",""Onion"",""Garlic"",""Orange"",""Bay Leaf""]",180,Brazilian,4
+Karniyarik,"[""Eggplant"",""Ground Beef"",""Onion"",""Green Pepper"",""Tomato Sauce"",""Olive Oil"",""Spices""]",75,Turkish,3
+Goi Cuon,"[""Rice Noodles"",""Shrimp"",""Pork"",""Bean Sprouts"",""Lettuce"",""Mint"",""Peanuts""]",45,Vietnamese,2
+Thai Green Curry,"[""Rice Noodles"",""Chicken"",""Coconut Milk"",""Red Curry Paste"",""Fish Sauce"",""Vegetables"",""Lime""]",60,Thai,3
+Hummus,"[""Chickpeas"",""Tahini"",""Lemon Juice"",""Garlic"",""Olive Oil"",""Parsley"",""Pita Bread""]",20,Lebanese,1
+Tortilla Espanola,"[""Potatoes"",""Onion"",""Eggs"",""Olive Oil"",""Salt"",""Pepper""]",50,Spanish,2
+Crepes,"[""Flour"",""Butter"",""Eggs"",""Sugar"",""Milk"",""Vanilla Extract""]",40,French,2

--- a/examples/recipes_cuisine/recipes.json
+++ b/examples/recipes_cuisine/recipes.json
@@ -5,9 +5,7 @@
     {
       "name": "cuisines",
       "type": "ai",
-      "prompt": "Generate 20 recipe cuisines.",
-      "random": true,
-      "replacement": false
+      "prompt": "Generate 20 recipe cuisines."
     }
   ],
   "columns": [
@@ -35,7 +33,9 @@
       "description": "type of cuisine",
       "type": "string",
       "fill_mode": "pick",
-      "source": "cuisines"
+      "source": "cuisines",
+      "random": true,
+      "replacement": false
     },
     {
       "name": "Difficulty Level",

--- a/examples/recipes_cuisine_meal/recipes.csv
+++ b/examples/recipes_cuisine_meal/recipes.csv
@@ -1,101 +1,101 @@
 Name,Ingredients,Cooking Time,Cuisine,Meal,Difficulty Level
-Baba Ghanoush,"[""Eggplant"",""Tahini"",""Lemon Juice"",""Garlic"",""Olive Oil""]",20,Lebanese,Appetizers,2
-Greek Frappe,"[""Instant Coffee"",""Sugar"",""Water"",""Milk""]",5,Mediterranean,Drinks,1
-Sambusas,"[""Lentils"",""Onion"",""Garlic"",""Ginger"",""Turmeric"",""Flour""]",15,Ethiopian,Appetizers,3
-Frittata,"[""Eggs"",""Cheese"",""Spinach"",""Tomatoes"",""Onion""]",25,Italian,Breakfast,2
-Tagine,"[""Chicken"",""Apricots"",""Almonds"",""Cinnamon"",""Ginger"",""Onion""]",45,Moroccan,Dinner,4
-Causa Rellena,"[""Potatoes"",""Chicken"",""Avocado"",""Mayonnaise"",""Lime""]",10,Peruvian,Appetizers,3
-Hotteok,"[""Flour"",""Sugar"",""Cinnamon"",""Yeast"",""Water""]",30,Korean,Desserts,3
-Pancakes,"[""Flour"",""Milk"",""Eggs"",""Sugar"",""Baking Powder""]",15,American,Breakfast,1
-Kir Royale,"[""Crème de Cassis"",""Champagne""]",5,French,Drinks,1
-Mochi,"[""Sweet Rice Flour"",""Sugar"",""Water"",""Red Bean Paste""]",20,Japanese,Desserts,3
-Paella,"[""Rice"",""Saffron"",""Seafood"",""Chicken"",""Vegetables""]",35,Spanish,Lunch,4
-Upma,"[""Semolina"",""Onion"",""Mustard Seeds"",""Curry Leaves"",""Vegetables""]",20,Indian,Breakfast,2
-Freddo Espresso,"[""Espresso"",""Ice"",""Sugar""]",5,Greek,Drinks,1
-Pão de Queijo,"[""Tapioca Flour"",""Cheese"",""Milk"",""Oil"",""Eggs""]",15,Brazilian,Appetizers,2
-Spring Rolls,"[""Rice Paper"",""Vegetables"",""Shrimp"",""Noodles"",""Peanut Sauce""]",25,Chinese,Appetizers,3
-Tacos,"[""Corn Tortillas"",""Ground Beef"",""Lettuce"",""Tomatoes"",""Cheese"",""Salsa""]",30,Mexican,Lunch,2
-Pho,"[""Rice Noodles"",""Beef"",""Broth"",""Herbs"",""Spices""]",10,Vietnamese,Breakfast,3
-Glühwein,"[""Red Wine"",""Cinnamon Sticks"",""Cloves"",""Orange Slices"",""Sugar""]",5,German,Drinks,1
-Kebab,"[""Lamb"",""Yogurt"",""Garlic"",""Spices"",""Onion""]",50,Turkish,Dinner,4
-Pad Thai,"[""Rice Noodles"",""Shrimp"",""Tofu"",""Peanuts"",""Bean Sprouts"",""Egg""]",35,Thai,Dinner,3
-Sangria,"[""Red wine"",""Chopped fruit"",""Brandy"",""Sugar""]",15,Spanish,Drinks,2
-Injera,"[""Teff flour"",""Water"",""Yeast""]",45,Ethiopian,Desserts,3
-Bibimbap,"[""Rice"",""Vegetables"",""Egg"",""Gochujang""]",30,Korean,Lunch,4
-Baklava,"[""Phyllo dough"",""Nuts"",""Butter"",""Syrup""]",60,Greek,Desserts,5
-Black Forest Cake,"[""Chocolate cake"",""Cherries"",""Whipped cream"",""Kirsch""]",90,German,Desserts,4
-Ca Phe Sua Da,"[""Coffee"",""Condensed milk"",""Hot water""]",5,Vietnamese,Drinks,1
-Butter Chicken,"[""Chicken"",""Tomato sauce"",""Butter"",""Cream"",""Spices""]",45,Indian,Dinner,3
-Dumplings,"[""Ground pork"",""Cabbage"",""Ginger"",""Soy sauce""]",35,Chinese,Lunch,3
-Pasta Carbonara,"[""Pasta"",""Eggs"",""Pancetta"",""Parmesan cheese"",""Black pepper""]",25,Italian,Lunch,2
-Greek Salad,"[""Tomatoes"",""Cucumbers"",""Onion"",""Olives"",""Feta cheese"",""Olive oil""]",10,Mediterranean,Drinks,1
-Iskender Kebab,"[""Lamb"",""Pita bread"",""Tomato sauce"",""Yogurt"",""Butter""]",50,Turkish,Dinner,4
-Croque Monsieur,"[""Bread"",""Ham"",""Cheese"",""Béchamel sauce""]",40,French,Lunch,2
-Margarita,"[""Tequila"",""Lime juice"",""Triple sec""]",5,Mexican,Drinks,1
-Causa Rellena,"[""Yellow potatoes"",""Avocado"",""Chicken"",""Mayonnaise""]",75,Peruvian,Desserts,3
-Tagine,"[""Meat"",""Vegetables"",""Spices"",""Dried fruit""]",80,Moroccan,Desserts,4
-Buffalo Wings,"[""Chicken wings"",""Hot sauce"",""Butter"",""Vinegar""]",10,American,Appetizers,2
-Falafel,"[""Chickpeas"",""Onion"",""Parsley"",""Spices""]",20,Lebanese,Lunch,3
-Mochi,"[""Glutinous rice flour"",""Sugar"",""Water"",""Filling""]",60,Japanese,Desserts,3
-Tom Yum Soup,"[""Lemongrass"",""Galangal"",""Lime leaves"",""Chili"",""Mushrooms"",""Shrimp""]",15,Thai,Appetizers,3
-Feijoada,"[""Black beans"",""Pork"",""Beef"",""Sausage"",""Rice""]",30,Brazilian,Lunch,4
-Greek Salad,"[""Feta cheese"",""Olive oil"",""Lemon juice"",""Oregano""]",15,Brazilian,Appetizers,2
-Gin Fizz,"[""Gin"",""Lemon juice"",""Sugar syrup"",""Soda water""]",5,Greek,Drinks,1
-Masala Chai,"[""Milk"",""Sugar"",""Cardamom"",""Almonds""]",10,Indian,Drinks,2
-Ethiopian Scrambled Eggs,"[""Eggs"",""Milk"",""Berbere spice"",""Onion"",""Tomato""]",20,Ethiopian,Breakfast,3
-Schweinshaxe,"[""Pork"",""Sauerkraut"",""Potatoes"",""Caraway seeds""]",120,German,Lunch,4
-Tangyuan,"[""Rice flour"",""Red bean paste"",""Sugar"",""Water""]",30,Chinese,Desserts,3
-Hummus,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil""]",15,Lebanese,Dinner,2
-Goi Cuon,"[""Rice paper"",""Shrimp"",""Pork"",""Vegetables"",""Noodles""]",30,Vietnamese,Breakfast,3
-Quiche Lorraine,"[""Eggs"",""Cream"",""Bacon"",""Gruyere cheese""]",50,French,Lunch,4
-Cappuccino,"[""Espresso"",""Steamed milk"",""Foamed milk""]",5,Italian,Drinks,1
-Moussaka,"[""Ground beef"",""Eggplant"",""Potatoes"",""Tomato sauce"",""Bechamel sauce""]",90,Turkish,Lunch,4
-Edamame,"[""Edamame"",""Soy sauce"",""Sesame oil"",""Salt""]",10,Japanese,Appetizers,1
-Briouats,"[""Almonds"",""Honey"",""Orange blossom water"",""Phyllo dough"",""Butter""]",60,Moroccan,Desserts,4
-Tortilla Española,"[""Eggs"",""Potatoes"",""Onions"",""Olive oil"",""Salt""]",40,Spanish,Breakfast,2
-Pad Thai,"[""Rice noodles"",""Shrimp"",""Tofu"",""Bean sprouts"",""Peanuts""]",30,Thai,Appetizers,3
-Full Breakfast,"[""Eggs"",""Bacon"",""Toast"",""Hash browns""]",25,American,Breakfast,2
-Somaek,"[""Soju"",""Beer"",""Sprite"",""Lemon""]",5,Korean,Drinks,1
-Enchiladas,"[""Corn tortillas"",""Chicken"",""Cheese"",""Salsa"",""Sour cream""]",40,Mexican,Lunch,2
-Ratatouille,"[""Eggplant"",""Zucchini"",""Bell peppers"",""Tomatoes"",""Olive oil""]",60,Mediterranean,Lunch,3
-Pisco Sour,"[""Pisco"",""Lime juice"",""Simple syrup"",""Egg white"",""Bitters""]",10,Peruvian,Drinks,2
-Tagine,"[""Chicken"",""Onions"",""Tomatoes"",""Spices"",""Olive Oil""]",90,Moroccan,Drinks,3
-Apple Pie,"[""Apples"",""Flour"",""Sugar"",""Butter"",""Cinnamon""]",75,American,Drinks,4
-Moussaka,"[""Eggplant"",""Ground Meat"",""Potatoes"",""Bechamel Sauce"",""Cheese""]",120,Mediterranean,Dinner,4
-Chicha Morada,"[""Purple Corn"",""Pineapple"",""Apples"",""Lime"",""Sugar""]",30,Peruvian,Drinks,1
-Paella,"[""Rice"",""Seafood"",""Chicken"",""Vegetables"",""Saffron""]",90,Spanish,Drinks,4
-Che Chuoi,"[""Bananas"",""Coconut Milk"",""Tapioca Pearls"",""Sugar"",""Peanuts""]",45,Vietnamese,Desserts,2
-Iskender Kebab,"[""Lamb"",""Pita Bread"",""Tomato Sauce"",""Yogurt"",""Butter""]",60,Turkish,Lunch,3
-Spanakopita,"[""Spinach"",""Feta Cheese"",""Phyllo Dough"",""Eggs"",""Onions""]",70,Greek,Breakfast,3
-Soupe à l'oignon gratinée,"[""Onions"",""Beef Broth"",""Bread"",""Cheese"",""Butter""]",50,French,Appetizers,3
-Mango Sticky Rice,"[""Sticky Rice"",""Mango"",""Coconut Milk"",""Sugar"",""Sesame Seeds""]",40,Thai,Desserts,2
-Glühwein,"[""Red Wine"",""Cinnamon Sticks"",""Cloves"",""Orange"",""Sugar""]",20,German,Drinks,1
-Congee,"[""Rice"",""Water"",""Chicken"",""Ginger"",""Scallions""]",60,Chinese,Breakfast,2
-Caipirinha,"[""Cachaça"",""Sugar"",""Lime"",""Ice""]",5,Brazilian,Drinks,1
-Samosa,"[""Potatoes"",""Peas"",""Spices"",""Flour"",""Oil""]",45,Indian,Appetizers,3
-Tamagoyaki,"[""Eggs"",""Soy Sauce"",""Sugar"",""Mirin"",""Dashi""]",15,Japanese,Breakfast,2
-Falafel,"[""Chickpeas"",""Onions"",""Parsley"",""Cilantro"",""Spices""]",50,Lebanese,Lunch,3
-Guacamole,"[""Avocados"",""Onion"",""Tomato"",""Lime Juice"",""Cilantro""]",10,Mexican,Appetizers,1
-Dabo Kolo,"[""Barley Flour"",""Water"",""Salt"",""Oil"",""Spices""]",30,Ethiopian,Desserts,2
-Lasagna,"[""Pasta Sheets"",""Ground Beef"",""Ricotta Cheese"",""Tomato Sauce"",""Mozzarella Cheese""]",90,Italian,Lunch,4
-Bibimbap,"[""Rice"",""Vegetables"",""Beef"",""Egg"",""Gochujang""]",45,Korean,Dinner,3
-Kimchi Pancakes,"[""Kimchi"",""Sesame oil"",""Soy sauce"",""Green onions""]",25,Korean,Appetizers,3
-Black Forest Cake,"[""Flour"",""Sugar"",""Eggs"",""Milk"",""Butter"",""Vanilla extract""]",60,German,Desserts,2
-Churros,"[""Flour"",""Sugar"",""Cinnamon"",""Eggs"",""Oil""]",30,Mexican,Desserts,2
-Shakshuka,"[""Eggs"",""Tomatoes"",""Onions"",""Bell peppers"",""Feta cheese"",""Olives"",""Olive oil""]",20,Mediterranean,Breakfast,2
-Samosa,"[""Potatoes"",""Peas"",""Carrots"",""Onions"",""Spices"",""Puff pastry""]",45,Indian,Appetizers,3
-Wat,"[""Berbere spice"",""Beef cubes"",""Onions"",""Garlic"",""Ginger"",""Tomato paste""]",90,Ethiopian,Dinner,4
-Torrijas,"[""Eggs"",""Milk"",""Sugar"",""Lemon zest"",""Cinnamon""]",30,Spanish,Desserts,2
-Ayran,"[""Yogurt"",""Water"",""Salt"",""Mint""]",5,Turkish,Drinks,1
-Briouats,"[""Phyllo dough"",""Spinach"",""Feta cheese"",""Onions"",""Eggs"",""Olive oil""]",40,Moroccan,Appetizers,3
-Mint Julep,"[""Bourbon"",""Sugar"",""Mint leaves"",""Water""]",5,American,Drinks,1
-Fried Rice,"[""Rice"",""Eggs"",""Green onions"",""Soy sauce"",""Vegetables""]",15,Chinese,Breakfast,2
-Baklava,"[""Phyllo dough"",""Walnuts"",""Honey"",""Cinnamon"",""Butter""]",75,Greek,Desserts,4
-Matcha Latte,"[""Matcha powder"",""Hot water"",""Milk"",""Sugar""]",10,Japanese,Drinks,1
-Hummus,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil"",""Pita bread""]",20,Lebanese,Appetizers,2
-Papa a la Huancaina,"[""Potatoes"",""Yellow chili paste"",""Lime juice"",""Vegetable oil""]",30,Peruvian,Appetizers,3
-Cappuccino,"[""Espresso"",""Steamed milk"",""Foamed milk""]",5,Italian,Drinks,1
-Pho,"[""Rice noodles"",""Beef"",""Bean sprouts"",""Cilantro"",""Lime"",""Hoisin sauce""]",60,Vietnamese,Dinner,3
-Thai Iced Tea,"[""Coconut milk"",""Lime juice"",""Sugar"",""Tea""]",10,Thai,Drinks,1
-Croissant,"[""Flour"",""Butter"",""Eggs"",""Sugar"",""Almonds""]",45,French,Lunch,3
+Kung Pao Chicken,"[""Chicken"",""Peanuts"",""Soy Sauce"",""Chili Peppers""]",30,Chinese,Lunch,3
+Beef Bourguignon,"[""Beef"",""Red Wine"",""Mushrooms"",""Onions""]",180,French,Dinner,4
+Hummus with Pita,"[""Chickpeas"",""Tahini"",""Lemon Juice"",""Olive Oil"",""Pita Bread""]",15,Lebanese,Appetizers,1
+Coxinha,"[""Chicken"",""Cream Cheese"",""Breadcrumbs"",""Onion""]",45,Brazilian,Appetizers,3
+Margarita,"[""Tequila"",""Lime Juice"",""Orange Liqueur"",""Salt""]",5,Mexican,Drinks,1
+Greek Salad,"[""Tomatoes"",""Cucumbers"",""Olives"",""Feta Cheese"",""Olive Oil""]",20,Mediterranean,Lunch,1
+Sushi Rolls,"[""Sushi Rice"",""Nori"",""Fish"",""Vegetables""]",60,Japanese,Dinner,4
+Injera with Wat,"[""Injera Bread"",""Meat Stew"",""Spices""]",90,Ethiopian,Lunch,3
+Moussaka,"[""Eggplant"",""Ground Meat"",""Potatoes"",""Bechamel Sauce""]",120,Greek,Dinner,4
+Sauerbraten,"[""Beef"",""Vinegar"",""Gingerbread"",""Raisins""]",150,German,Lunch,4
+Turkish Delight,"[""Milk"",""Sugar"",""Pistachios"",""Rosewater""]",60,Turkish,Desserts,2
+Che Chuoi,"[""Tapioca pearls"",""Coconut milk"",""Sugar"",""Mango"",""Pandan leaves""]",45,Vietnamese,Desserts,3
+Tortilla Espanola,"[""Eggs"",""Potatoes"",""Onions"",""Olive oil"",""Salt""]",35,Spanish,Breakfast,2
+Lemonade,"[""Lemon"",""Sugar"",""Water"",""Mint""]",5,American,Drinks,1
+Samosas,"[""Samosa pastry"",""Potatoes"",""Peas"",""Spices"",""Oil""]",50,Indian,Appetizers,3
+Moroccan Mint Tea,"[""Mint leaves"",""Sugar"",""Lime"",""Sparkling water""]",10,Moroccan,Drinks,2
+Causa Rellena,"[""Potatoes"",""Yellow chili"",""Lime juice"",""Vegetable oil"",""Salt"",""Pepper""]",40,Peruvian,Lunch,4
+Aperol Spritz,"[""Prosecco"",""Aperol"",""Soda water"",""Orange slice""]",5,Italian,Drinks,1
+Bibimbap,"[""Rice"",""Vegetables"",""Beef"",""Egg"",""Soy sauce"",""Sesame oil""]",45,Korean,Lunch,3
+Pad Thai,"[""Rice noodles"",""Shrimp"",""Tofu"",""Bean sprouts"",""Peanuts"",""Tamarind paste""]",60,Thai,Dinner,4
+Masala Dosa,"[""Rice"",""Urad Dal"",""Fenugreek Seeds"",""Potatoes"",""Onions"",""Spices""]",45,Indian,Breakfast,3
+Hummus,"[""Chickpeas"",""Tahini"",""Lemon Juice"",""Garlic"",""Olive Oil""]",10,Lebanese,Appetizers,1
 Caipirinha,"[""Cachaça"",""Sugar"",""Lime""]",5,Brazilian,Drinks,1
+Pisco Sour,"[""Pisco"",""Lime Juice"",""Simple Syrup"",""Egg White"",""Angostura Bitters""]",7,Peruvian,Drinks,2
+Greek Salad,"[""Tomatoes"",""Cucumbers"",""Onion"",""Olives"",""Feta Cheese"",""Olive Oil"",""Oregano""]",15,Mediterranean,Lunch,2
+Tej,"[""Honey"",""Water"",""Gesho""]",1440,Ethiopian,Drinks,3
+Bruschetta,"[""Bread"",""Tomatoes"",""Garlic"",""Basil"",""Olive Oil""]",10,Italian,Appetizers,1
+Mint Lemonade,"[""Mint"",""Lemon"",""Sugar"",""Water""]",5,Moroccan,Drinks,1
+Kimchi Fried Rice,"[""Kimchi"",""Rice"",""Egg"",""Gochujang"",""Sesame Oil"",""Vegetables""]",20,Korean,Lunch,2
+Tzatziki,"[""Greek Yogurt"",""Cucumber"",""Garlic"",""Olive Oil"",""Lemon Juice"",""Dill""]",10,Greek,Appetizers,1
+Sauerbraten,"[""Beef"",""Vinegar"",""Gingerbread"",""Raisins""]",180,German,Lunch,4
+Mango Sticky Rice,"[""Mango"",""Sticky Rice"",""Coconut Milk"",""Sugar""]",45,Chinese,Desserts,2
+Pad See Ew,"[""Rice Noodles"",""Chinese Broccoli"",""Egg"",""Soy Sauce""]",25,Thai,Dinner,3
+Croque Monsieur,"[""Bread"",""Ham"",""Cheese"",""Bechamel Sauce""]",20,French,Lunch,2
+Goi Cuon,"[""Rice Paper"",""Shrimp"",""Pork"",""Vegetables"",""Rice Noodles""]",30,Vietnamese,Appetizers,3
+Paella,"[""Rice"",""Saffron"",""Seafood"",""Chicken"",""Vegetables""]",60,Spanish,Lunch,4
+Churros,"[""Flour"",""Water"",""Sugar"",""Cinnamon""]",35,Mexican,Desserts,2
+Tamagoyaki,"[""Eggs"",""Soy Sauce"",""Sugar"",""Mirin""]",15,Japanese,Breakfast,1
+Menemen,"[""Tomatoes"",""Peppers"",""Eggs"",""Onion"",""Spices""]",25,Turkish,Lunch,2
+Buffalo Wings,"[""Chicken Wings"",""Hot Sauce"",""Butter"",""Vinegar""]",40,American,Appetizers,2
+Lemonade,"[""ice"",""soda"",""lemon""]",5,American,Drinks,1
+Gavurdagi Salad,"[""feta cheese"",""olives"",""tomatoes"",""cucumber""]",10,Turkish,Appetizers,2
+Quesadillas,"[""tortillas"",""chicken"",""cheese"",""salsa""]",30,Mexican,Lunch,3
+Baklava,"[""phyllo dough"",""walnuts"",""cinnamon"",""sugar syrup""]",45,Lebanese,Desserts,4
+Éclair,"[""puff pastry"",""cream"",""chocolate""]",60,French,Lunch,3
+Pad Thai,"[""rice noodles"",""shrimp"",""vegetables"",""peanut sauce""]",20,Thai,Dinner,2
+Sushi,"[""rice"",""seaweed"",""tuna"",""avocado""]",15,Japanese,Lunch,2
+Bibimbap,"[""rice"",""vegetables"",""beef"",""gochujang""]",25,Korean,Lunch,3
+Spanakopita,"[""phyllo dough"",""spinach"",""feta cheese"",""eggs""]",35,Greek,Desserts,4
+Injera with Wat,"[""injera"",""stew"",""vegetables"",""spices""]",40,Ethiopian,Lunch,3
+Frappe,"[""Espresso"",""Ice"",""Milk"",""Sugar""]",5,Mediterranean,Drinks,1
+Sesame Balls,"[""Glutinous rice flour"",""Sesame seeds"",""Red bean paste"",""Sugar"",""Oil""]",40,Chinese,Desserts,3
+Brigadeiro,"[""Condensed milk"",""Cocoa powder"",""Butter"",""Chocolate sprinkles""]",20,Brazilian,Desserts,2
+Paella,"[""Rice"",""Saffron"",""Chicken"",""Seafood"",""Vegetables""]",60,Spanish,Dinner,3
+Gulab Jamun,"[""Milk powder"",""All-purpose flour"",""Ghee"",""Sugar"",""Cardamom"",""Rose water""]",50,Indian,Desserts,4
+Radler,"[""Beer"",""Lemonade""]",3,German,Drinks,1
+Ceviche,"[""White fish"",""Lime juice"",""Red onion"",""Cilantro"",""Aji peppers""]",25,Peruvian,Lunch,3
+Tiramisu,"[""Ladyfingers"",""Espresso"",""Mascarpone cheese"",""Eggs"",""Sugar"",""Cocoa powder""]",30,Italian,Desserts,2
+Chebakia,"[""Flour"",""Sesame seeds"",""Anise"",""Saffron"",""Cinnamon"",""Honey""]",60,Moroccan,Desserts,3
+Pho,"[""Beef bones"",""Rice noodles"",""Beef"",""Spices"",""Herbs""]",90,Vietnamese,Dinner,4
+Baklava,"[""Filo pastry"",""Walnuts"",""Butter"",""Sugar"",""Lemon juice""]",60,Turkish,Desserts,3
+Kartoffelpuffer,"[""Potatoes"",""Salt"",""Pepper"",""Oil""]",20,German,Appetizers,1
+Chicken Biryani,"[""Chicken"",""Basmati rice"",""Yogurt"",""Spices""]",90,Indian,Dinner,4
+Tzatziki,"[""Yogurt"",""Cucumber"",""Garlic"",""Olive oil""]",10,Greek,Drinks,2
+Che Chuoi,"[""Tapioca starch"",""Coconut milk"",""Sugar"",""Pandan leaves""]",45,Vietnamese,Desserts,3
+Hummus,"[""Chickpeas"",""Tahini"",""Lemon juice"",""Garlic"",""Olive oil""]",15,Lebanese,Lunch,2
+Mazamorra Morada,"[""Purple corn"",""Pineapple"",""Quince"",""Apple"",""Lime"",""Cinnamon"",""Clove""]",70,Peruvian,Desserts,4
+Paella,"[""Rice"",""Chicken"",""Seafood"",""Peas"",""Peppers"",""Saffron""]",50,Spanish,Dinner,3
+Caprese Salad,"[""Tomatoes"",""Mozzarella"",""Basil"",""Olive oil""]",20,Italian,Lunch,2
+Lemonade,"[""Lemon"",""Sugar"",""Water""]",5,American,Drinks,1
+Orange Juice,"[""Orange juice"",""Oranges"",""Ice""]",5,Mediterranean,Drinks,1
+Doro Wat,"[""Injera"",""Doro Wat"",""Berbere spice""]",90,Ethiopian,Dinner,4
+Mango Sticky Rice,"[""Mango"",""Sticky Rice"",""Coconut Milk""]",45,Thai,Desserts,3
+Sake,"[""Sake"",""Rice"",""Water""]",60,Japanese,Drinks,2
+Tangyuan,"[""Red Bean Paste"",""Glutinous Rice Flour"",""Sugar""]",30,Chinese,Desserts,3
+Couscous,"[""Couscous"",""Vegetables"",""Spices""]",40,Moroccan,Lunch,2
+Croissant,"[""Croissant"",""Butter"",""Sugar""]",25,French,Breakfast,3
+Huevos Rancheros,"[""Eggs"",""Tortillas"",""Salsa""]",20,Mexican,Breakfast,2
+Kimchi Fried Rice,"[""Kimchi"",""Rice"",""Eggs""]",30,Korean,Dinner,2
+Pão de Queijo,"[""Pão de Queijo"",""Cheese"",""Tapioca Flour""]",35,Brazilian,Appetizers,1
+Tabbouleh,"[""Bulgur"",""Parsley"",""Mint"",""Tomato"",""Onion"",""Lemon juice"",""Olive oil""]",45,Lebanese,Dinner,3
+Gyeran Mari,"[""Eggs"",""Rice"",""Seaweed"",""Vegetables"",""Soy sauce""]",20,Korean,Breakfast,2
+Aperol Spritz,"[""Prosecco"",""Aperol"",""Soda water"",""Orange slice""]",5,Italian,Drinks,1
+Goi Cuon,"[""Rice paper"",""Shrimp"",""Vermicelli noodles"",""Vegetables"",""Peanut sauce""]",10,Vietnamese,Drinks,2
+Apfelstrudel,"[""Apples"",""Flour"",""Butter"",""Sugar"",""Cinnamon""]",60,German,Desserts,3
+Chicken Biryani,"[""Chicken"",""Rice"",""Spices"",""Yogurt"",""Onions""]",90,Indian,Dinner,4
+Papa a la Huancaína,"[""Potatoes"",""Aji Amarillo"",""Lime juice"",""Vegetable oil""]",25,Peruvian,Appetizers,2
+Greek Salad,"[""Tomatoes"",""Cucumber"",""Feta cheese"",""Olives"",""Onion"",""Olive oil""]",35,Mediterranean,Lunch,3
+Beef Bourguignon,"[""Beef"",""Red wine"",""Carrots"",""Onions"",""Mushrooms"",""Bacon""]",120,French,Dinner,4
+Menemen,"[""Eggs"",""Tomatoes"",""Green peppers"",""Onions"",""Spices""]",30,Turkish,Breakfast,2
+Sangria,"[""Red wine"",""Orange"",""Lemon"",""Sugar"",""Cinnamon""]",10,Spanish,Drinks,2
+Mango Sticky Rice,"[""Sticky rice"",""Mango"",""Coconut milk"",""Sugar"",""Salt""]",40,Thai,Breakfast,3
+Souffle,"[""Egg"",""Flour"",""Sugar"",""Milk"",""Vanilla extract""]",50,Chinese,Desserts,4
+Black Bean Dip,"[""Black beans"",""Onion"",""Garlic"",""Olive oil"",""Lime""]",20,Brazilian,Appetizers,2
+Misir Wot,"[""Lentils"",""Onion"",""Garlic"",""Tomato paste"",""Berbere spice""]",60,Ethiopian,Lunch,3
+Margarita,"[""Tequila"",""Lime juice"",""Agave nectar"",""Salt""]",5,Mexican,Drinks,1
+Ouzo,"[""Ouzo"",""Water"",""Ice""]",2,Greek,Drinks,1
+Mochi,"[""Mochi"",""Red bean paste"",""Sugar"",""Water""]",30,Japanese,Desserts,3
+Pancakes,"[""Pancake mix"",""Milk"",""Eggs"",""Butter"",""Syrup""]",20,American,Breakfast,1
+Harcha,"[""Semolina"",""Milk"",""Honey"",""Butter"",""Cinnamon""]",35,Moroccan,Breakfast,2

--- a/examples/recipes_cuisine_meal/recipes.json
+++ b/examples/recipes_cuisine_meal/recipes.json
@@ -5,9 +5,7 @@
     {
       "name": "cuisines",
       "type": "ai",
-      "prompt": "Generate 20 recipe cuisines.",
-      "random": true,
-      "replacement": false
+      "prompt": "Generate 20 recipe cuisines."
     },
     {
       "name": "meals",
@@ -19,9 +17,7 @@
         "Desserts",
         "Appetizers",
         "Drinks"
-      ],
-      "random": true,
-      "replacement": true
+      ]
     }
   ],
   "columns": [
@@ -49,14 +45,18 @@
       "description": "type of cuisine",
       "type": "string",
       "fill_mode": "pick",
-      "source": "cuisines"
+      "source": "cuisines",
+      "random": true,
+      "replacement": false
     },
     {
       "name": "Meal",
       "description": "meal of the recipe",
       "type": "string",
       "fill_mode": "pick",
-      "source": "meals"
+      "source": "meals",
+      "random": true,
+      "replacement": true
     },
     {
       "name": "Difficulty Level",

--- a/examples/recipes_cuisine_meal_ingredients/recipes.csv
+++ b/examples/recipes_cuisine_meal_ingredients/recipes.csv
@@ -1,0 +1,101 @@
+Name,Ing1,Ing2,Ingredients,Cooking Time,Cuisine,Meal,Difficulty Level
+Spanish Olives,Olive Oil,Salt,"[""Olive Oil"",""Salt"",""Garlic"",""Oregano""]",15,Spanish,Appetizers,1
+German Cream Tart,Sour Cream,Sugar,"[""Sour Cream"",""Sugar"",""Eggs"",""Flour""]",45,German,Desserts,3
+Lebanese Flatbread,Salt,Flour,"[""Salt"",""Flour"",""Water"",""Zaatar""]",30,Lebanese,Breakfast,2
+Japanese Cheese Omelet,Cheese,Eggs,"[""Cheese"",""Eggs"",""Soy Sauce"",""Dashi""]",20,Japanese,Drinks,2
+Italian Sausage Pasta,Garlic,Sausage,"[""Garlic"",""Sausage"",""Pasta"",""Tomato Sauce""]",50,Italian,Dinner,3
+Peruvian Milk Soup,Milk,Pasta,"[""Milk"",""Pasta"",""Potatoes"",""Cheese""]",35,Peruvian,Breakfast,2
+Brazilian Cinnamon Salad,Cinnamon,Vinegar,"[""Cinnamon"",""Vinegar"",""Tomatoes"",""Lettuce""]",25,Brazilian,Lunch,1
+American Yogurt Smoothie,Yogurt,Nutmeg,"[""Yogurt"",""Nutmeg"",""Banana"",""Honey""]",5,American,Drinks,1
+Indian Broccoli Bites,Broccoli,Olive Oil,"[""Broccoli"",""Olive Oil"",""Turmeric"",""Chili Powder""]",20,Indian,Appetizers,2
+Greek Pasta Salad,Pasta,Potatoes,"[""Pasta"",""Potatoes"",""Olives"",""Feta Cheese""]",30,Greek,Appetizers,1
+Chinese Butter Milk Stew,Butter,Milk,"[""Butter"",""Milk"",""Soy Sauce"",""Ginger"",""Garlic""]",25,Chinese,Lunch,3
+Mediterranean Avocado Celery Smoothie,Avocado,Celery,"[""Avocado"",""Celery"",""Yogurt"",""Honey"",""Spinach""]",10,Mediterranean,Drinks,2
+Korean Butter Ketchup Pizza,Ketchup,Butter,"[""Ketchup"",""Butter"",""Flour"",""Pepperoni"",""Cheese""]",35,Korean,Lunch,4
+Vietnamese Eggs Tomatoes Salad,Eggs,Tomatoes,"[""Eggs"",""Tomatoes"",""Lettuce"",""Cucumber"",""Vinegar""]",15,Vietnamese,Appetizers,2
+Thai Tuna Cheese Soup,Tuna,Cheese,"[""Tuna"",""Cheese"",""Coconut Milk"",""Lemongrass"",""Chili""]",40,Thai,Desserts,5
+Moroccan Brown Sugar Mayonnaise Dip,Brown Sugar,Mayonnaise,"[""Brown Sugar"",""Mayonnaise"",""Garlic"",""Lemon Juice"",""Paprika""]",20,Moroccan,Lunch,3
+French Celery Baking Powder Muffins,Celery,Baking Powder,"[""Celery"",""Baking Powder"",""Flour"",""Eggs"",""Sugar""]",30,French,Breakfast,1
+Mexican Lemon Broccoli Burritos,Lemon,Broccoli,"[""Lemon"",""Broccoli"",""Tortillas"",""Beans"",""Cheese""]",45,Mexican,Dinner,4
+British Jam Ketchup Drink,Jam,Ketchup,"[""Jam"",""Ketchup"",""Water"",""Lemon Juice"",""Sugar""]",5,British,Drinks,2
+Ethiopian Vanilla Extract Garlic Coffee,Vanilla Extract,Garlic,"[""Vanilla Extract"",""Garlic"",""Coffee Beans"",""Water"",""Sugar""]",10,Ethiopian,Drinks,3
+Moroccan Basil Vanilla Extract Salad,Basil,Vanilla Extract,"[""Basil"",""Vanilla Extract""]",25,Moroccan,Dinner,3
+American Chicken Breast Skewers,Chicken Breast,Chicken Breast,"[""Chicken Breast"",""Chicken Breast""]",15,American,Appetizers,2
+Thai Flour Maple Syrup Pancakes,Flour,Maple Syrup,"[""Flour"",""Maple Syrup""]",30,Thai,Dinner,3
+Ethiopian Mushrooms and Bacon Scramble,Mushrooms,Bacon,"[""Mushrooms"",""Bacon""]",20,Ethiopian,Breakfast,2
+Brazilian Potatoes with Peanut Butter Sauce,Potatoes,Peanut Butter,"[""Potatoes"",""Peanut Butter""]",40,Brazilian,Lunch,3
+Peruvian Maple Syrup Cinnamon Rolls,Maple Syrup,Cinnamon,"[""Maple Syrup"",""Cinnamon""]",50,Peruvian,Lunch,4
+Vietnamese Mayonnaise Sour Cream Dip,Mayonnaise,Sour Cream,"[""Mayonnaise"",""Sour Cream""]",5,Vietnamese,Breakfast,1
+Spanish Peanut Butter Salmon,Peanut Butter,Salmon,"[""Peanut Butter"",""Salmon""]",35,Spanish,Dinner,3
+Lebanese Parsley Rice Pilaf,Parsley,Rice,"[""Parsley"",""Rice""]",30,Lebanese,Dinner,2
+Indian Heavy Cream Carrots Soup,Heavy Cream,Carrots,"[""Heavy Cream"",""Carrots""]",25,Indian,Appetizers,2
+Korean Onion Yeast Rolls,Yeast,Onion,"[""Yeast"",""Onion"",""Flour"",""Sugar"",""Salt"",""Water"",""Milk"",""Eggs""]",35,Korean,Desserts,3
+British Brown Sugar Vinegar Oatmeal,Vinegar,Brown Sugar,"[""Vinegar"",""Brown Sugar"",""Oatmeal"",""Water"",""Salt"",""Milk""]",20,British,Breakfast,2
+Greek Chocolate Chips Spinach Smoothie,Spinach,Chocolate Chips,"[""Spinach"",""Chocolate Chips"",""Yogurt"",""Milk"",""Honey""]",5,Greek,Drinks,1
+Japanese Cilantro Sausage Bites,Sausage,Cilantro,"[""Sausage"",""Cilantro"",""Soy Sauce"",""Ginger"",""Garlic"",""Sesame Oil""]",15,Japanese,Appetizers,2
+Italian Mustard Onion Crostini,Onion,Mustard,"[""Onion"",""Mustard"",""Bread"",""Olive Oil"",""Garlic"",""Salt"",""Pepper""]",10,Italian,Appetizers,1
+Mexican Honey Lemon Chicken,Honey,Lemon,"[""Honey"",""Lemon"",""Chicken"",""Chili Powder"",""Cumin"",""Garlic"",""Onion"",""Olive Oil""]",25,Mexican,Lunch,3
+Chinese Basil Sugar Pancakes,Sugar,Basil,"[""Sugar"",""Basil"",""Flour"",""Eggs"",""Milk"",""Baking Powder""]",30,Chinese,Breakfast,2
+German Pepper Rice Juice,Rice,Pepper,"[""Rice"",""Pepper"",""Water"",""Lemon Juice"",""Sugar""]",5,German,Drinks,1
+Mediterranean Spinach Bacon Rolls,Bacon,Spinach,"[""Bacon"",""Spinach"",""Puff Pastry"",""Feta Cheese"",""Olive Oil""]",15,Mediterranean,Appetizers,2
+French Avocado Tomatoes Quiche,Tomatoes,Avocado,"[""Tomatoes"",""Avocado"",""Eggs"",""Cream"",""Cheese"",""Pastry Crust""]",40,French,Dinner,3
+Panamanian Chocolate Jam Pudding,Chocolate Chips,Jam,"[""Chocolate Chips"",""Jam"",""Sugar"",""Eggs"",""Milk""]",50,Peruvian,Dinner,4
+Austrian Soy Sauce Yeast Smoothie,Soy Sauce,Yeast,"[""Soy Sauce"",""Yeast"",""Water"",""Lime""]",5,German,Drinks,2
+Egyptian Nutmeg Heavy Cream Soup,Nutmeg,Heavy Cream,"[""Nutmeg"",""Heavy Cream"",""Chicken Broth"",""Onion"",""Garlic""]",35,Lebanese,Lunch,3
+Japanese Cilantro Honey Ice Cream,Cilantro,Honey,"[""Cilantro"",""Honey"",""Milk"",""Cream"",""Sugar""]",60,Chinese,Desserts,5
+Angolan Ground Beef Parsley Stew,Ground Beef,Parsley,"[""Ground Beef"",""Parsley"",""Tomatoes"",""Onion"",""Garlic""]",40,Ethiopian,Dinner,2
+Korean Baking Powder Yogurt Bread,Baking Powder,Yogurt,"[""Baking Powder"",""Yogurt"",""Flour"",""Sugar"",""Eggs""]",45,Thai,Dinner,3
+Kenyan Carrots Soy Sauce Salad,Carrots,Soy Sauce,"[""Carrots"",""Soy Sauce"",""Lettuce"",""Tomatoes""]",15,Mediterranean,Drinks,1
+Ghanaian Salmon Tuna Sandwich,Salmon,Tuna,"[""Salmon"",""Tuna"",""Bread"",""Mayonnaise""]",20,American,Desserts,2
+Colombian Mustard Mushrooms Pasta,Mustard,Mushrooms,"[""Mustard"",""Mushrooms"",""Pasta"",""Cream"",""Parmesan Cheese""]",30,Italian,Dinner,3
+Canadian Pepper Ground Beef Soup,Pepper,Ground Beef,"[""Pepper"",""Ground Beef"",""Broth"",""Celery"",""Carrots""]",30,French,Lunch,2
+Korean Bacon and Salt Omelet,Salt,Bacon,"[""Bacon"",""Salt"",""Eggs"",""Green Onions""]",20,Korean,Breakfast,2
+Indian Bacon and Maple Syrup Dessert,Bacon,Maple Syrup,"[""Bacon"",""Maple Syrup"",""Flour"",""Sugar"",""Nuts""]",35,Indian,Desserts,3
+Greek Olive Oil and Jam Cake,Olive Oil,Jam,"[""Olive Oil"",""Jam"",""Flour"",""Sugar"",""Eggs""]",40,Greek,Desserts,3
+Vietnamese Cilantro and Salt Soda,Cilantro,Salt,"[""Cilantro"",""Salt"",""Lime"",""Soda Water""]",5,Vietnamese,Drinks,1
+Mexican Sour Cream and Pepper Flan,Sour Cream,Pepper,"[""Sour Cream"",""Pepper"",""Eggs"",""Vanilla""]",45,Mexican,Desserts,4
+British Carrots and Onion Soup,Carrots,Onion,"[""Carrots"",""Onion"",""Vegetable Broth"",""Thyme""]",25,British,Breakfast,2
+Brazilian Pepper and Garlic Shrimp,Pepper,Garlic,"[""Pepper"",""Garlic"",""Shrimp"",""Olive Oil"",""Parsley""]",30,Brazilian,Lunch,3
+Japanese Potatoes and Brown Sugar Dumplings,Potatoes,Brown Sugar,"[""Potatoes"",""Brown Sugar"",""Soy Sauce"",""Ginger""]",50,Japanese,Appetizers,4
+Spanish Heavy Cream and Avocado Smoothie,Heavy Cream,Avocado,"[""Heavy Cream"",""Avocado"",""Honey"",""Lime Juice""]",10,Spanish,Drinks,1
+Moroccan Lemon and Mushrooms Tagine,Lemon,Mushrooms,"[""Lemon"",""Mushrooms"",""Olives"",""Couscous"",""Spices""]",40,Moroccan,Lunch,3
+Moroccan Eggs and Peanut Butter Stew,Eggs,Peanut Butter,"[""Eggs"",""Peanut Butter"",""Onion"",""Tomato"",""Spices""]",45,Moroccan,Dinner,2
+German Tomatoes and Flour Crackers,Tomatoes,Flour,"[""Tomatoes"",""Flour"",""Salt"",""Pepper"",""Water""]",25,German,Appetizers,1
+Indian Cheese and Mayonnaise Sandwich,Cheese,Mayonnaise,"[""Cheese"",""Mayonnaise"",""Bread"",""Lettuce"",""Tomato""]",15,Indian,Breakfast,1
+Chinese Butter and Nutmeg Hot Drink,Butter,Nutmeg,"[""Butter"",""Nutmeg"",""Water"",""Sugar""]",5,Chinese,Drinks,1
+Spanish Soy Sauce and Salmon Scramble,Soy Sauce,Salmon,"[""Soy Sauce"",""Salmon"",""Eggs"",""Onion"",""Garlic""]",20,Spanish,Breakfast,2
+Japanese Broccoli and Lemon Salad,Broccoli,Lemon,"[""Broccoli"",""Lemon"",""Lettuce"",""Cucumber"",""Dressing""]",10,Japanese,Lunch,1
+Mediterranean Yeast and Cinnamon Bread,Yeast,Cinnamon,"[""Yeast"",""Cinnamon"",""Flour"",""Water"",""Sugar""]",60,Mediterranean,Dinner,3
+American Tuna and Yeast Melt,Tuna,Yeast,"[""Tuna"",""Yeast"",""Cheese"",""Bread"",""Mayonnaise""]",25,American,Breakfast,2
+French Milk and Sausage Soup,Milk,Sausage,"[""Milk"",""Sausage"",""Onion"",""Potatoes"",""Carrots""]",35,French,Desserts,2
+Italian Ketchup and Vinegar Bruschetta,Ketchup,Vinegar,"[""Ketchup"",""Vinegar"",""Bread"",""Garlic"",""Olive Oil""]",15,Italian,Breakfast,1
+British Brown Sugar and Potato Dessert,Brown Sugar,Potatoes,"[""Brown Sugar"",""Potatoes""]",35,British,Desserts,2
+Thai Chicken and Carrot Curry,Chicken Breast,Carrots,"[""Chicken Breast"",""Carrots""]",25,Thai,Lunch,3
+Vietnamese Basil and Ketchup Salad,Basil,Ketchup,"[""Basil"",""Ketchup""]",15,Vietnamese,Lunch,1
+Korean Tuna and Spinach Pancake,Spinach,Tuna,"[""Spinach"",""Tuna""]",20,Korean,Appetizers,2
+Lebanese Ground Beef and Mustard Cocktail,Mustard,Ground Beef,"[""Mustard"",""Ground Beef""]",5,Lebanese,Drinks,1
+Ethiopian Celery and Sugar Cereal,Celery,Sugar,"[""Celery"",""Sugar""]",10,Ethiopian,Breakfast,1
+Peruvian Pasta with Butter Sauce,Pasta,Butter,"[""Pasta"",""Butter""]",40,Peruvian,Dinner,3
+Brazilian Vinegar and Yogurt Drink,Vinegar,Yogurt,"[""Vinegar"",""Yogurt""]",5,Brazilian,Drinks,1
+Mexican Vanilla Cream,Vanilla Extract,Heavy Cream,"[""Vanilla Extract"",""Heavy Cream""]",15,Mexican,Lunch,2
+Greek Avocado and Vanilla Toast,Avocado,Vanilla Extract,"[""Avocado"",""Vanilla Extract""]",10,Greek,Breakfast,1
+Chinese Nutmeg and Basil Tart,Nutmeg,Basil,"[""Nutmeg"",""Basil"",""Sugar"",""Soy Sauce"",""Ginger""]",30,Chinese,Desserts,1
+Lebanese Sausage and Chocolate Chips Pancakes,Sausage,Chocolate Chips,"[""Sausage"",""Chocolate Chips"",""Milk"",""Eggs"",""Vanilla Extract""]",45,Lebanese,Desserts,2
+Spanish Flour and Broccoli Fritters,Flour,Broccoli,"[""Flour"",""Broccoli"",""Eggs"",""Salt"",""Pepper""]",60,Spanish,Dinner,3
+Moroccan Honey and Soy Sauce Glazed Chicken,Honey,Soy Sauce,"[""Honey"",""Soy Sauce"",""Garlic"",""Ginger"",""Sesame Oil""]",35,Moroccan,Dinner,4
+Ethiopian Garlic and Milk Gravy,Garlic,Milk,"[""Garlic"",""Milk"",""Butter"",""Salt"",""Pepper""]",25,Ethiopian,Dinner,2
+American Maple Syrup and Mustard Cookies,Maple Syrup,Mustard,"[""Maple Syrup"",""Mustard"",""Baking Soda"",""Flour"",""Vanilla Extract""]",15,American,Desserts,1
+Mediterranean Baking Powder and Parsley Drink,Baking Powder,Parsley,"[""Baking Powder"",""Parsley"",""Lemon Juice"",""Olive Oil"",""Water""]",5,Mediterranean,Drinks,3
+Japanese Cinnamon and Celery Stir-Fry,Cinnamon,Celery,"[""Cinnamon"",""Celery"",""Soy Sauce"",""Rice Wine"",""Sesame Oil""]",20,Japanese,Lunch,2
+Thai Ground Beef and Pasta Noodles,Ground Beef,Pasta,"[""Ground Beef"",""Pasta"",""Soy Sauce"",""Chili"",""Garlic""]",40,Thai,Lunch,3
+British Chocolate Chips and Sour Cream Smoothie,Chocolate Chips,Sour Cream,"[""Chocolate Chips"",""Sour Cream"",""Milk"",""Sugar"",""Vanilla Extract""]",10,British,Drinks,1
+Cuban Chocolate and Black Olives Salad,Parsley,Chicken Breast,"[""Parsley"",""Chicken Breast"",""Chocolate"",""Black Olives"",""Cumin""]",35,Indian,Breakfast,3
+Kenyan Coconut and Milk Ice Cream,Mushrooms,Olive Oil,"[""Mushrooms"",""Olive Oil"",""Coconut"",""Milk"",""Vanilla Extract""]",45,Korean,Desserts,2
+Syrian Lemon and Peanut Stew,Salmon,Cheese,"[""Salmon"",""Cheese"",""Lemon"",""Peanut"",""Paprika""]",60,Mexican,Breakfast,4
+Moroccan Almond and Avocado Crepes,Onion,Honey,"[""Onion"",""Honey"",""Almond"",""Avocado"",""Salt""]",25,Brazilian,Desserts,1
+Spanish Avocado and Yogurt Shake,Sugar,Tomatoes,"[""Sugar"",""Tomatoes"",""Avocado"",""Yogurt"",""Cinnamon""]",15,German,Drinks,2
+Argentinian Pineapple and Yogurt Pancakes,Rice,Rice,"[""Rice"",""Pineapple"",""Yogurt"",""Butter"",""Sugar""]",40,Peruvian,Drinks,3
+Irish Chicken and Almond Pie,Peanut Butter,Cilantro,"[""Peanut Butter"",""Cilantro"",""Chicken"",""Almond"",""Salt""]",55,Greek,Desserts,4
+Egyptian Strawberry and Chocolate Muffins,Mayonnaise,Spinach,"[""Mayonnaise"",""Spinach"",""Strawberry"",""Chocolate"",""Flour""]",30,French,Breakfast,2
+Filipino Chili Powder and Peas Curry,Yogurt,Baking Powder,"[""Yogurt"",""Baking Powder"",""Chili Powder"",""Peas"",""Cumin""]",50,Italian,Desserts,3
+Cambodian Coconut and Basil Soup,Jam,Eggs,"[""Jam"",""Eggs"",""Coconut"",""Basil"",""Salt""]",20,Vietnamese,Dinner,1

--- a/examples/recipes_cuisine_meal_ingredients/recipes.json
+++ b/examples/recipes_cuisine_meal_ingredients/recipes.json
@@ -1,0 +1,91 @@
+{
+  "name": "recipes",
+  "description": "table of recipes",
+  "sources": [
+    {
+      "name": "cuisines",
+      "type": "ai",
+      "prompt": "Generate 20 recipe cuisines."
+    },
+    {
+      "name": "ingredients",
+      "type": "ai",
+      "prompt": "Generate 50 common ingredients."
+    },
+    {
+      "name": "meals",
+      "type": "list",
+      "options": [
+        "Dinner",
+        "Breakfast",
+        "Lunch",
+        "Desserts",
+        "Appetizers",
+        "Drinks"
+      ]
+    }
+  ],
+  "columns": [
+    {
+      "name": "Name",
+      "description": "recipe name",
+      "type": "string",
+      "fill_mode": "ai",
+      "context_length": 5
+    },
+    {
+      "name": "Ing1",
+      "description": "the first ingredient recipe must include",
+      "type": "string",
+      "fill_mode": "pick",
+      "source": "ingredients",
+      "random": true,
+      "replacement": false
+    },
+    {
+      "name": "Ing2",
+      "description": "the second ingredient recipe must include",
+      "type": "string",
+      "fill_mode": "pick",
+      "source": "ingredients",
+      "random": true,
+      "replacement": false
+    },
+    {
+      "name": "Ingredients",
+      "description": "list of ingredients",
+      "type": "array",
+      "fill_mode": "ai"
+    },
+    {
+      "name": "Cooking Time",
+      "description": "time required to cook the recipe (minutes)",
+      "type": "integer",
+      "fill_mode": "ai"
+    },
+    {
+      "name": "Cuisine",
+      "description": "type of cuisine",
+      "type": "string",
+      "fill_mode": "pick",
+      "source": "cuisines",
+      "random": true,
+      "replacement": false
+    },
+    {
+      "name": "Meal",
+      "description": "meal of the recipe",
+      "type": "string",
+      "fill_mode": "pick",
+      "source": "meals",
+      "random": true,
+      "replacement": true
+    },
+    {
+      "name": "Difficulty Level",
+      "description": "difficulty level of the recipe (1-5)",
+      "type": "integer",
+      "fill_mode": "ai"
+    }
+  ]
+}

--- a/examples/recipes_for_customers/recipes.json
+++ b/examples/recipes_for_customers/recipes.json
@@ -5,9 +5,7 @@
     {
       "name": "customer",
       "type": "linked",
-      "table": "customers",
-      "column": "Name",
-      "context_columns": ["Name", "Age", "Job", "Country", "Taste Preference"]
+      "table": "customers"
     }
   ],
   "columns": [
@@ -28,7 +26,15 @@
       "description": "The customer for whom this recipe is created",
       "type": "string",
       "fill_mode": "pick",
-      "source": "customer"
+      "source": "customer",
+      "linked_column": "Name",
+      "linked_context_columns": [
+        "Name",
+        "Age",
+        "Job",
+        "Country",
+        "Taste Preference"
+      ]
     },
     {
       "name": "Reason",

--- a/services/table/models.go
+++ b/services/table/models.go
@@ -12,6 +12,8 @@ type TableGenColumn struct {
 	Type          string `json:"type"`
 	FillMode      string `json:"fill_mode"`
 	Source        string `json:"source"`
+	Random        bool   `json:"random"`
+	Replacement   bool   `json:"replacement"`
 	Repeat        int    `json:"repeat"`
 	ContextLength int    `json:"context_length"`
 }

--- a/services/table/models.go
+++ b/services/table/models.go
@@ -7,15 +7,17 @@ import (
 )
 
 type TableGenColumn struct {
-	Name          string `json:"name"`
-	Description   string `json:"description"`
-	Type          string `json:"type"`
-	FillMode      string `json:"fill_mode"`
-	Source        string `json:"source"`
-	Random        bool   `json:"random"`
-	Replacement   bool   `json:"replacement"`
-	Repeat        int    `json:"repeat"`
-	ContextLength int    `json:"context_length"`
+	Name                 string   `json:"name"`
+	Description          string   `json:"description"`
+	Type                 string   `json:"type"`
+	FillMode             string   `json:"fill_mode"`
+	Source               string   `json:"source"`
+	Random               bool     `json:"random"`
+	Replacement          bool     `json:"replacement"`
+	Repeat               int      `json:"repeat"`
+	ContextLength        int      `json:"context_length"`
+	LinkedColumn         string   `json:"linked_column"`
+	LinkedContextColumns []string `json:"linked_context_columns"`
 }
 
 type TableGenRequest struct {

--- a/services/table/rows_generator.go
+++ b/services/table/rows_generator.go
@@ -37,6 +37,7 @@ type AIRowsGenerator struct {
 	table          *ent.TableMeta
 	missingColumns []*ent.TableColumn
 	contextColumns []*ent.TableColumn
+	indexerMap     map[string]*source.Indexer
 	sourceMap      map[string]source.Source
 	generated      []map[string]*schema.CellValue
 	contextLength  int
@@ -63,6 +64,7 @@ func NewRowsGenerator(ctx context.Context, params GenerateRowsRequest, db *ent.C
 
 		total:       params.Count,
 		batchSize:   params.Batch,
+		indexerMap:  make(map[string]*source.Indexer),
 		sourceMap:   make(map[string]source.Source),
 		saveTo:      params.SaveTo,
 		temperature: params.Temperature,
@@ -108,12 +110,11 @@ func NewRowsGenerator(ctx context.Context, params GenerateRowsRequest, db *ent.C
 			if len(c.Source) == 0 {
 				return nil, errors.New("invalid source")
 			}
-			var so source.Source
-			so, err := generator.columnSource(ctx, c)
+			idx, err := generator.columnSourceIndexer(ctx, meta.Sources[c.Source], c)
 			if err != nil {
 				return nil, err
 			}
-			generator.sourceMap[c.Nanoid] = so
+			generator.indexerMap[c.Nanoid] = idx
 			continue
 		}
 		generator.missingColumns = append(generator.missingColumns, c)
@@ -201,9 +202,9 @@ func (g *AIRowsGenerator) prepareRows(ctx context.Context, batch int) error {
 		for n := 0; n < batch; n++ {
 			row := map[string]*schema.CellValue{}
 			for _, col := range g.table.Edges.Columns {
-				so, ok := g.sourceMap[col.Nanoid]
+				idx, ok := g.indexerMap[col.Nanoid]
 				if ok {
-					v, err := so.Next(ctx)
+					v, err := idx.Next(ctx)
 					if err != nil {
 						return err
 					}
@@ -275,13 +276,16 @@ func (g *AIRowsGenerator) chat(ctx context.Context) (*client.ChatResponse, error
 	})
 }
 
-func (g *AIRowsGenerator) columnSource(ctx context.Context, column *ent.TableColumn) (source.Source, error) {
+func (g *AIRowsGenerator) columnSourceIndexer(ctx context.Context, raw json.RawMessage, column *ent.TableColumn) (*source.Indexer, error) {
+	if so, ok := g.sourceMap[column.Source]; ok {
+		return source.NewIndexer(so, column.Random, column.Replacement, column.Repeat), nil
+	}
 	var so source.Source
-	sourceType := gjson.GetBytes(column.Source, "type").String()
+	sourceType := gjson.GetBytes(raw, "type").String()
 	switch sourceType {
 	case "list":
 		var ls source.ListSource
-		err := json.Unmarshal(column.Source, &ls)
+		err := json.Unmarshal(raw, &ls)
 		if err != nil {
 			return nil, err
 		}
@@ -292,22 +296,22 @@ func (g *AIRowsGenerator) columnSource(ctx context.Context, column *ent.TableCol
 		so = &ls
 	case "ai":
 		var ls source.AISource
-		err := json.Unmarshal(column.Source, &ls)
+		err := json.Unmarshal(raw, &ls)
 		if err != nil {
 			return nil, err
 		}
-		err = ls.Init(ctx, g.ai, column)
+		err = ls.Init(ctx, g.ai, column, g.model)
 		if err != nil {
 			return nil, err
 		}
 		so = &ls
 	case "linked":
 		var ls source.LinkedSource
-		err := json.Unmarshal(column.Source, &ls)
+		err := json.Unmarshal(raw, &ls)
 		if err != nil {
 			return nil, err
 		}
-		err = ls.Init(ctx, g.db, column)
+		err = ls.Init(ctx, g.db)
 		if err != nil {
 			return nil, err
 		}
@@ -315,7 +319,8 @@ func (g *AIRowsGenerator) columnSource(ctx context.Context, column *ent.TableCol
 	default:
 		return nil, fmt.Errorf("unknow source type %s", sourceType)
 	}
-	return so, nil
+	g.sourceMap[column.Source] = so
+	return source.NewIndexer(so, column.Random, column.Replacement, column.Repeat), nil
 }
 
 func (g *AIRowsGenerator) generate(ctx context.Context, batch int) ([]map[string]*schema.CellValue, error) {

--- a/services/table/rows_generator.go
+++ b/services/table/rows_generator.go
@@ -278,7 +278,7 @@ func (g *AIRowsGenerator) chat(ctx context.Context) (*client.ChatResponse, error
 
 func (g *AIRowsGenerator) columnSourceIndexer(ctx context.Context, raw json.RawMessage, column *ent.TableColumn) (*source.Indexer, error) {
 	if so, ok := g.sourceMap[column.Source]; ok {
-		return source.NewIndexer(so, column.Random, column.Replacement, column.Repeat), nil
+		return source.NewIndexer(so, column), nil
 	}
 	var so source.Source
 	sourceType := gjson.GetBytes(raw, "type").String()
@@ -320,7 +320,7 @@ func (g *AIRowsGenerator) columnSourceIndexer(ctx context.Context, raw json.RawM
 		return nil, fmt.Errorf("unknow source type %s", sourceType)
 	}
 	g.sourceMap[column.Source] = so
-	return source.NewIndexer(so, column.Random, column.Replacement, column.Repeat), nil
+	return source.NewIndexer(so, column), nil
 }
 
 func (g *AIRowsGenerator) generate(ctx context.Context, batch int) ([]map[string]*schema.CellValue, error) {

--- a/services/table/rows_generator_test.go
+++ b/services/table/rows_generator_test.go
@@ -27,9 +27,10 @@ func TestRowsGenerator_PrepareRows(t *testing.T) {
 	sc := &source.ListSource{Options: []string{"foo"}}
 	err := sc.Init(context.TODO())
 	require.NoError(t, err)
+	idx := source.NewIndexer(sc, false, false, 1)
 	generator := &AIRowsGenerator{
-		sourceMap: map[string]source.Source{
-			"c1": sc,
+		indexerMap: map[string]*source.Indexer{
+			"c1": idx,
 		},
 		table: &ent.TableMeta{Edges: ent.TableMetaEdges{
 			Columns: []*ent.TableColumn{
@@ -322,7 +323,10 @@ func TestRowsGenerator_Prompt(t *testing.T) {
 	t.Run("pick-type column", func(t *testing.T) {
 		db := db.NewTestDB()
 		ctx := context.Background()
-		tb, err := db.TableMeta.Create().SetName("table").SetDescription("bar").Save(ctx)
+		sc := &source.ListSource{Options: []string{"a", "b"}, Type: "list"}
+		sb, err := json.Marshal(sc)
+		require.NoError(t, err)
+		tb, err := db.TableMeta.Create().SetName("table").SetDescription("bar").SetSources(map[string]json.RawMessage{"so": sb}).Save(ctx)
 		require.NoError(t, err)
 		col, err := db.TableColumn.Create().
 			SetName("c").
@@ -330,13 +334,10 @@ func TestRowsGenerator_Prompt(t *testing.T) {
 			SetTablemeta(tb).
 			SetType(tablecolumn.TypeString).Save(ctx)
 		require.NoError(t, err)
-		sc := &source.ListSource{Options: []string{"a", "b"}, Type: "list"}
-		sb, err := json.Marshal(sc)
-		require.NoError(t, err)
 		col2, err := db.TableColumn.Create().
 			SetName("c2").
 			SetFillMode(tablecolumn.FillModePick).
-			SetSource(sb).
+			SetSource("so").
 			SetTablemeta(tb).
 			SetType(tablecolumn.TypeString).Save(ctx)
 		require.NoError(t, err)

--- a/services/table/rows_generator_test.go
+++ b/services/table/rows_generator_test.go
@@ -27,7 +27,9 @@ func TestRowsGenerator_PrepareRows(t *testing.T) {
 	sc := &source.ListSource{Options: []string{"foo"}}
 	err := sc.Init(context.TODO())
 	require.NoError(t, err)
-	idx := source.NewIndexer(sc, false, false, 1)
+	idx := source.NewIndexer(sc, &ent.TableColumn{
+		Random: false,
+	})
 	generator := &AIRowsGenerator{
 		indexerMap: map[string]*source.Indexer{
 			"c1": idx,

--- a/services/table/source/ai.go
+++ b/services/table/source/ai.go
@@ -21,7 +21,6 @@ var reflector = jsonschema.Reflector{
 }
 
 type AISource struct {
-	indexer
 	Type    string   `json:"type"`
 	Prompt  string   `json:"prompt"`
 	Options []string `json:"options"`
@@ -31,7 +30,7 @@ type data struct {
 	Options []string
 }
 
-func (as *AISource) Init(ctx context.Context, ai ai.AiService, column *ent.TableColumn) error {
+func (as *AISource) Init(ctx context.Context, ai ai.AiService, column *ent.TableColumn, model string) error {
 	builder := promptbuilder.NewColumnOptionsBuilder(column.Name, column.Description, as.Prompt)
 
 	if len(as.Options) > 0 {
@@ -47,6 +46,7 @@ func (as *AISource) Init(ctx context.Context, ai ai.AiService, column *ent.Table
 		Temperature:     0.8,
 		PresencePenalty: 1.0,
 		MaxOutputTokens: OptionGenMaxTokens,
+		Model:           model,
 	})
 	if err != nil {
 		return err
@@ -57,10 +57,13 @@ func (as *AISource) Init(ctx context.Context, ai ai.AiService, column *ent.Table
 		return err
 	}
 	as.Options = append(as.Options, d.Options...)
-	as.indexer = newIndexer(as.Random, as.Replacement, len(as.Options), as.Repeat)
 	return nil
 }
 
-func (as *AISource) Next(ctx context.Context) (*schema.CellValue, error) {
-	return &schema.CellValue{Value: as.Options[as.nextIndex()]}, nil
+func (as *AISource) Next(ctx context.Context, idx int) (*schema.CellValue, error) {
+	return &schema.CellValue{Value: as.Options[idx]}, nil
+}
+
+func (as *AISource) Total() int {
+	return len(as.Options)
 }

--- a/services/table/source/ai_test.go
+++ b/services/table/source/ai_test.go
@@ -55,7 +55,7 @@ func TestSource_AI(t *testing.T) {
 			} else {
 				require.Equal(t, so.Options, []string{"foo", "bar"})
 			}
-			indexer := NewIndexer(so, false, false, 0)
+			indexer := NewIndexer(so, &ent.TableColumn{Random: false})
 
 			v, err := indexer.Next(ctx)
 			require.NoError(t, err)

--- a/services/table/source/ai_test.go
+++ b/services/table/source/ai_test.go
@@ -48,7 +48,7 @@ func TestSource_AI(t *testing.T) {
 			if hasOption {
 				so.Options = []string{"go"}
 			}
-			err = so.Init(ctx, aiService, &ent.TableColumn{Name: "table", Description: "a table"})
+			err = so.Init(ctx, aiService, &ent.TableColumn{Name: "table", Description: "a table"}, "")
 			require.NoError(t, err)
 			if hasOption {
 				require.Equal(t, so.Options, []string{"go", "foo", "bar"})

--- a/services/table/source/ai_test.go
+++ b/services/table/source/ai_test.go
@@ -42,9 +42,8 @@ func TestSource_AI(t *testing.T) {
 				},
 			}
 			so := &AISource{
-				indexer: newIndexer(false, false, 20, 0),
-				Type:    "ai",
-				Prompt:  "aiai",
+				Type:   "ai",
+				Prompt: "aiai",
 			}
 			if hasOption {
 				so.Options = []string{"go"}
@@ -56,7 +55,9 @@ func TestSource_AI(t *testing.T) {
 			} else {
 				require.Equal(t, so.Options, []string{"foo", "bar"})
 			}
-			v, err := so.Next(ctx)
+			indexer := NewIndexer(so, false, false, 0)
+
+			v, err := indexer.Next(ctx)
 			require.NoError(t, err)
 			if hasOption {
 				require.Equal(t, "go", v.Value)

--- a/services/table/source/linked.go
+++ b/services/table/source/linked.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"errors"
 
 	"github.com/Yiling-J/tablepilot/ent"
 	"github.com/Yiling-J/tablepilot/ent/schema"
@@ -12,13 +13,11 @@ import (
 )
 
 type LinkedSource struct {
-	Type           string `json:"type"`
-	db             *ent.Client
-	Table          string   `json:"table"`
-	Column         string   `json:"column"`
-	ContextColumns []string `json:"context_columns"`
-	data           []*ent.TableRow
-	columns        []*ent.TableColumn
+	Type    string `json:"type"`
+	db      *ent.Client
+	Table   string `json:"table"`
+	data    []*ent.TableRow
+	columns []*ent.TableColumn
 }
 
 func (ls *LinkedSource) Init(ctx context.Context, db *ent.Client) error {
@@ -40,19 +39,19 @@ func (ls *LinkedSource) Init(ctx context.Context, db *ent.Client) error {
 	return nil
 }
 
-func (ls *LinkedSource) getLinkedCellValue(idx int) (*schema.CellValue, error) {
+func (ls *LinkedSource) getLinkedCellValue(idx int, column string, contextColumns []string) (*schema.CellValue, error) {
 	indexer := util.NewColumnIndexer(ls.columns)
 	row := ls.data[idx]
 	lv := &schema.CellValue{}
-	idx, err := indexer.GetColumnIndexByNanoid(ls.Column)
+	idx, err := indexer.GetColumnIndexByNanoid(column)
 	if err != nil {
 		return nil, err
 	}
 	lv.Value = row.Cells[idx].Value
 
-	if len(ls.ContextColumns) > 0 {
+	if len(contextColumns) > 0 {
 		values := map[string]any{}
-		for _, c := range ls.ContextColumns {
+		for _, c := range contextColumns {
 			cc, err := indexer.GetColumnByNanoid(c)
 			if err != nil {
 				return nil, err
@@ -76,7 +75,28 @@ func (ls *LinkedSource) getLinkedCellValue(idx int) (*schema.CellValue, error) {
 }
 
 func (ls *LinkedSource) Next(ctx context.Context, idx int) (*schema.CellValue, error) {
-	return ls.getLinkedCellValue(idx)
+	return nil, errors.New("not implemented")
+}
+
+func (ls *LinkedSource) NextLinked(ctx context.Context, idx int, column string, contextColumns []string) (*schema.CellValue, error) {
+	ids := map[string]bool{}
+	names := map[string]string{}
+	for _, col := range ls.columns {
+		ids[col.Nanoid] = true
+		names[col.Name] = col.Nanoid
+	}
+
+	// column name -> column id
+	if v, ok := names[column]; ok {
+		column = v
+	}
+	for i, c := range contextColumns {
+		if v, ok := names[c]; ok {
+			contextColumns[i] = v
+		}
+	}
+
+	return ls.getLinkedCellValue(idx, column, contextColumns)
 }
 
 func (ls *LinkedSource) Total() int {

--- a/services/table/source/linked.go
+++ b/services/table/source/linked.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/Yiling-J/tablepilot/ent"
 	"github.com/Yiling-J/tablepilot/ent/schema"
@@ -13,17 +12,16 @@ import (
 )
 
 type LinkedSource struct {
-	indexer
 	Type           string `json:"type"`
 	db             *ent.Client
 	Table          string   `json:"table"`
 	Column         string   `json:"column"`
 	ContextColumns []string `json:"context_columns"`
 	data           []*ent.TableRow
-	_column        *ent.TableColumn // the column which need to be get
+	columns        []*ent.TableColumn
 }
 
-func (ls *LinkedSource) Init(ctx context.Context, db *ent.Client, column *ent.TableColumn) error {
+func (ls *LinkedSource) Init(ctx context.Context, db *ent.Client) error {
 	ls.db = db
 	data, err := ls.db.TableRow.Query().Where(
 		tablerow.HasTablemetaWith(tablemeta.Nanoid(ls.Table)),
@@ -32,55 +30,29 @@ func (ls *LinkedSource) Init(ctx context.Context, db *ent.Client, column *ent.Ta
 		return err
 	}
 	ls.data = data
-	ls._column = column
-	ls.indexer = newIndexer(ls.Random, ls.Replacement, len(ls.data), ls.Repeat)
+	columns, err := ls.db.TableColumn.Query().Where(
+		tablecolumn.HasTablemetaWith(tablemeta.Nanoid(ls.Table)),
+	).Order(ent.Asc(tablerow.FieldID)).All(ctx)
+	if err != nil {
+		return err
+	}
+	ls.columns = columns
 	return nil
 }
 
-func linkedSource(ctx context.Context, db *ent.Client, column *ent.TableColumn) (*LinkedSource, error) {
-	var s LinkedSource
-	err := json.Unmarshal(column.Source, &s)
-	if err != nil {
-		return nil, err
-	}
-	s.db = db
-	err = s.Init(ctx, db, column)
-	if err != nil {
-		return nil, err
-	}
-	return &s, nil
-}
-
-func GetLinkedCellValue(ctx context.Context, db *ent.Client, column *ent.TableColumn, linkedRow string) (*schema.CellValue, error) {
-	so, err := linkedSource(ctx, db, column)
-	if err != nil {
-		return nil, err
-	}
-	linkedTable := so.Table
-	columns, err := db.TableColumn.Query().Where(
-		tablecolumn.HasTablemetaWith(tablemeta.Nanoid(linkedTable)),
-	).All(ctx)
-	if err != nil {
-		return nil, err
-	}
-	indexer := util.NewColumnIndexer(columns)
-	row, err := db.TableRow.Query().Where(
-		tablerow.HasTablemetaWith(tablemeta.Nanoid(linkedTable)),
-		tablerow.Nanoid(linkedRow),
-	).First(ctx)
-	if err != nil {
-		return nil, err
-	}
+func (ls *LinkedSource) getLinkedCellValue(idx int) (*schema.CellValue, error) {
+	indexer := util.NewColumnIndexer(ls.columns)
+	row := ls.data[idx]
 	lv := &schema.CellValue{}
-	idx, err := indexer.GetColumnIndexByNanoid(so.Column)
+	idx, err := indexer.GetColumnIndexByNanoid(ls.Column)
 	if err != nil {
 		return nil, err
 	}
 	lv.Value = row.Cells[idx].Value
 
-	if len(so.ContextColumns) > 0 {
+	if len(ls.ContextColumns) > 0 {
 		values := map[string]any{}
-		for _, c := range so.ContextColumns {
+		for _, c := range ls.ContextColumns {
 			cc, err := indexer.GetColumnByNanoid(c)
 			if err != nil {
 				return nil, err
@@ -103,7 +75,10 @@ func GetLinkedCellValue(ctx context.Context, db *ent.Client, column *ent.TableCo
 	return lv, nil
 }
 
-func (ls *LinkedSource) Next(ctx context.Context) (*schema.CellValue, error) {
-	row := ls.data[ls.nextIndex()]
-	return GetLinkedCellValue(ctx, ls.db, ls._column, row.Nanoid)
+func (ls *LinkedSource) Next(ctx context.Context, idx int) (*schema.CellValue, error) {
+	return ls.getLinkedCellValue(idx)
+}
+
+func (ls *LinkedSource) Total() int {
+	return len(ls.data)
 }

--- a/services/table/source/linked_test.go
+++ b/services/table/source/linked_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Yiling-J/tablepilot/ent"
 	"github.com/Yiling-J/tablepilot/ent/schema"
 	"github.com/Yiling-J/tablepilot/ent/tablecolumn"
 	"github.com/Yiling-J/tablepilot/infra/db"
@@ -37,16 +38,14 @@ func TestSource_LinkedContextColumns(t *testing.T) {
 	}).Exec(ctx)
 	require.NoError(t, err)
 	so := &LinkedSource{
-		db:             db,
-		Table:          tb.Nanoid,
-		Column:         c1.Nanoid,
-		ContextColumns: []string{c1.Nanoid, c2.Nanoid},
+		db:    db,
+		Table: tb.Nanoid,
 	}
 
 	require.NoError(t, err)
 	err = so.Init(ctx, db)
 	require.NoError(t, err)
-	indexer := NewIndexer(so, false, false, 0)
+	indexer := NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: c1.Nanoid, LinkedContextColumns: []string{c1.Nanoid, c2.Nanoid}})
 	v, err := indexer.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "foo", v.Value)

--- a/services/table/source/linked_test.go
+++ b/services/table/source/linked_test.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/Yiling-J/tablepilot/ent/schema"
@@ -44,19 +43,11 @@ func TestSource_LinkedContextColumns(t *testing.T) {
 		ContextColumns: []string{c1.Nanoid, c2.Nanoid},
 	}
 
-	b, err := json.Marshal(so)
 	require.NoError(t, err)
-	col, err := db.TableColumn.Create().
-		SetName("c3").
-		SetType(tablecolumn.TypeString).
-		SetFillMode(tablecolumn.FillModePick).
-		SetSource(b).
-		SetTablemeta(tb).
-		Save(ctx)
+	err = so.Init(ctx, db)
 	require.NoError(t, err)
-	err = so.Init(ctx, db, col)
-	require.NoError(t, err)
-	v, err := so.Next(ctx)
+	indexer := NewIndexer(so, false, false, 0)
+	v, err := indexer.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "foo", v.Value)
 	require.Equal(t, map[string]any{
@@ -64,7 +55,7 @@ func TestSource_LinkedContextColumns(t *testing.T) {
 		"c2": map[string]any{"data": float64(1), "description": "c2d"},
 	}, v.ContextValue)
 
-	v, err = so.Next(ctx)
+	v, err = indexer.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "bar", v.Value)
 	require.Equal(t, map[string]any{

--- a/services/table/source/list.go
+++ b/services/table/source/list.go
@@ -7,16 +7,18 @@ import (
 )
 
 type ListSource struct {
-	indexer
 	Type    string   `json:"type"`
 	Options []string `json:"options"`
 }
 
 func (ls *ListSource) Init(ctx context.Context) error {
-	ls.indexer = newIndexer(ls.Random, ls.Replacement, len(ls.Options), ls.Repeat)
 	return nil
 }
 
-func (ls *ListSource) Next(ctx context.Context) (*schema.CellValue, error) {
-	return &schema.CellValue{Value: ls.Options[ls.nextIndex()]}, nil
+func (ls *ListSource) Next(ctx context.Context, idx int) (*schema.CellValue, error) {
+	return &schema.CellValue{Value: ls.Options[idx]}, nil
+}
+
+func (ls *ListSource) Total() int {
+	return len(ls.Options)
 }

--- a/services/table/source/list_test.go
+++ b/services/table/source/list_test.go
@@ -10,13 +10,13 @@ import (
 func TestSource_List(t *testing.T) {
 	ctx := context.TODO()
 	so := &ListSource{
-		indexer: newIndexer(false, false, 5, 0),
 		Type:    "list",
 		Options: []string{"a", "b", "c"},
 	}
 	err := so.Init(ctx)
 	require.NoError(t, err)
-	v, err := so.Next(ctx)
+	indexer := NewIndexer(so, false, false, 0)
+	v, err := indexer.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "a", v.Value)
 }

--- a/services/table/source/list_test.go
+++ b/services/table/source/list_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Yiling-J/tablepilot/ent"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +16,7 @@ func TestSource_List(t *testing.T) {
 	}
 	err := so.Init(ctx)
 	require.NoError(t, err)
-	indexer := NewIndexer(so, false, false, 0)
+	indexer := NewIndexer(so, &ent.TableColumn{Random: false})
 	v, err := indexer.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "a", v.Value)

--- a/services/table/source/source.go
+++ b/services/table/source/source.go
@@ -8,10 +8,12 @@ import (
 )
 
 type Source interface {
-	Next(ctx context.Context) (*schema.CellValue, error)
+	Next(ctx context.Context, idx int) (*schema.CellValue, error)
+	Total() int
 }
 
-type indexer struct {
+type Indexer struct {
+	source      Source
 	Random      bool `json:"random,omitempty"`
 	Replacement bool `json:"replacement,omitempty"`
 	Repeat      int  `json:"repeat,omitempty"`
@@ -21,21 +23,22 @@ type indexer struct {
 	picked      map[int]bool
 }
 
-func newIndexer(random, replacement bool, total, repeat int) indexer {
+func NewIndexer(source Source, random, replacement bool, repeat int) *Indexer {
 	if repeat == 0 {
 		repeat = 1
 	}
-	return indexer{
+	return &Indexer{
+		source:      source,
 		Random:      random,
 		Replacement: replacement,
 		Repeat:      repeat,
-		total:       total,
+		total:       source.Total(),
 		current:     -1,
 		picked:      map[int]bool{},
 	}
 }
 
-func (i *indexer) nextIndex() int {
+func (i *Indexer) nextIndex() int {
 	if i.Repeat > 1 && i.repeated < i.Repeat && i.current != -1 {
 		i.repeated += 1
 		return i.current
@@ -65,4 +68,8 @@ func (i *indexer) nextIndex() int {
 		}
 	}
 	return i.current
+}
+
+func (i *Indexer) Next(ctx context.Context) (*schema.CellValue, error) {
+	return i.source.Next(ctx, i.nextIndex())
 }

--- a/services/table/source/source.go
+++ b/services/table/source/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand/v2"
 
+	"github.com/Yiling-J/tablepilot/ent"
 	"github.com/Yiling-J/tablepilot/ent/schema"
 )
 
@@ -13,40 +14,36 @@ type Source interface {
 }
 
 type Indexer struct {
-	source      Source
-	Random      bool `json:"random,omitempty"`
-	Replacement bool `json:"replacement,omitempty"`
-	Repeat      int  `json:"repeat,omitempty"`
-	repeated    int
-	total       int
-	current     int
-	picked      map[int]bool
+	source   Source
+	column   *ent.TableColumn
+	repeated int
+	total    int
+	current  int
+	picked   map[int]bool
 }
 
-func NewIndexer(source Source, random, replacement bool, repeat int) *Indexer {
-	if repeat == 0 {
-		repeat = 1
+func NewIndexer(source Source, column *ent.TableColumn) *Indexer {
+	if column.Repeat == 0 {
+		column.Repeat = 1
 	}
 	return &Indexer{
-		source:      source,
-		Random:      random,
-		Replacement: replacement,
-		Repeat:      repeat,
-		total:       source.Total(),
-		current:     -1,
-		picked:      map[int]bool{},
+		source:  source,
+		column:  column,
+		total:   source.Total(),
+		current: -1,
+		picked:  map[int]bool{},
 	}
 }
 
 func (i *Indexer) nextIndex() int {
-	if i.Repeat > 1 && i.repeated < i.Repeat && i.current != -1 {
+	if i.column.Repeat > 1 && i.repeated < i.column.Repeat && i.current != -1 {
 		i.repeated += 1
 		return i.current
 	}
 	i.repeated = 1
 
-	if i.Random {
-		if !i.Replacement {
+	if i.column.Random {
+		if !i.column.Replacement {
 			options := []int{}
 			if len(i.picked) == i.total {
 				i.picked = map[int]bool{}
@@ -71,5 +68,10 @@ func (i *Indexer) nextIndex() int {
 }
 
 func (i *Indexer) Next(ctx context.Context) (*schema.CellValue, error) {
-	return i.source.Next(ctx, i.nextIndex())
+	switch ts := i.source.(type) {
+	case *LinkedSource:
+		return ts.NextLinked(ctx, i.nextIndex(), i.column.LinkedColumn, i.column.LinkedContextColumns)
+	default:
+		return i.source.Next(ctx, i.nextIndex())
+	}
 }

--- a/services/table/source/source_test.go
+++ b/services/table/source/source_test.go
@@ -3,6 +3,7 @@ package source
 import (
 	"testing"
 
+	"github.com/Yiling-J/tablepilot/ent"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,14 +12,19 @@ func TestSource_Indexer(t *testing.T) {
 		Type:    "list",
 		Options: []string{"a", "b", "c", "d", "e"},
 	}
-	indexer := NewIndexer(so, false, true, 0)
+	indexer := NewIndexer(so, &ent.TableColumn{
+		Random: false,
+	})
 	nums := []int{}
 	for i := 0; i < 10; i++ {
 		nums = append(nums, indexer.nextIndex())
 	}
 	require.Equal(t, []int{0, 1, 2, 3, 4, 0, 1, 2, 3, 4}, nums)
 
-	indexer = NewIndexer(so, true, true, 0)
+	indexer = NewIndexer(so, &ent.TableColumn{
+		Random:      true,
+		Replacement: true,
+	})
 	numsCounter := map[int]int{}
 	nums = []int{}
 	for i := 0; i < 50; i++ {
@@ -48,7 +54,9 @@ func TestSource_Indexer(t *testing.T) {
 	require.True(t, gt > 0)
 	require.True(t, eq >= 0)
 
-	indexer = NewIndexer(so, true, false, 0)
+	indexer = NewIndexer(so, &ent.TableColumn{
+		Random: true,
+	})
 	nums = []int{}
 	for i := 0; i < 10; i++ {
 		nums = append(nums, indexer.nextIndex())
@@ -59,7 +67,10 @@ func TestSource_Indexer(t *testing.T) {
 		}
 	}
 
-	indexer = NewIndexer(so, false, true, 2)
+	indexer = NewIndexer(so, &ent.TableColumn{
+		Random: false,
+		Repeat: 2,
+	})
 	nums = []int{}
 	for i := 0; i < 10; i++ {
 		nums = append(nums, indexer.nextIndex())

--- a/services/table/source/source_test.go
+++ b/services/table/source/source_test.go
@@ -7,14 +7,18 @@ import (
 )
 
 func TestSource_Indexer(t *testing.T) {
-	indexer := newIndexer(false, true, 5, 0)
+	so := &ListSource{
+		Type:    "list",
+		Options: []string{"a", "b", "c", "d", "e"},
+	}
+	indexer := NewIndexer(so, false, true, 0)
 	nums := []int{}
 	for i := 0; i < 10; i++ {
 		nums = append(nums, indexer.nextIndex())
 	}
 	require.Equal(t, []int{0, 1, 2, 3, 4, 0, 1, 2, 3, 4}, nums)
 
-	indexer = newIndexer(true, true, 5, 0)
+	indexer = NewIndexer(so, true, true, 0)
 	numsCounter := map[int]int{}
 	nums = []int{}
 	for i := 0; i < 50; i++ {
@@ -44,7 +48,7 @@ func TestSource_Indexer(t *testing.T) {
 	require.True(t, gt > 0)
 	require.True(t, eq >= 0)
 
-	indexer = newIndexer(true, false, 5, 0)
+	indexer = NewIndexer(so, true, false, 0)
 	nums = []int{}
 	for i := 0; i < 10; i++ {
 		nums = append(nums, indexer.nextIndex())
@@ -55,7 +59,7 @@ func TestSource_Indexer(t *testing.T) {
 		}
 	}
 
-	indexer = newIndexer(false, true, 5, 2)
+	indexer = NewIndexer(so, false, true, 2)
 	nums = []int{}
 	for i := 0; i < 10; i++ {
 		nums = append(nums, indexer.nextIndex())

--- a/services/table/source/validate.go
+++ b/services/table/source/validate.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"github.com/Yiling-J/tablepilot/ent"
-	"github.com/Yiling-J/tablepilot/ent/tablecolumn"
 	"github.com/Yiling-J/tablepilot/ent/tablemeta"
 
 	"github.com/tidwall/gjson"
@@ -56,37 +55,6 @@ func ValidateSource(ctx context.Context, raw json.RawMessage, db *ent.Client) (S
 			return nil, err
 		}
 		ls.Table = tb.Nanoid
-		if ls.Column == "" {
-			return nil, ErrColumnNameOrIdEmpty()
-		}
-		col, err := db.TableColumn.Query().Where(
-			tablecolumn.HasTablemetaWith(tablemeta.Nanoid(tb.Nanoid)),
-			tablecolumn.Or(
-				tablecolumn.Name(ls.Column),
-				tablecolumn.Nanoid(ls.Column),
-			)).Only(ctx)
-		if err != nil {
-			if ent.IsNotFound(err) {
-				return nil, ErrColumnNotFound(ls.Column)
-			}
-			return nil, err
-		}
-		ls.Column = col.Nanoid
-		for i, c := range ls.ContextColumns {
-			col, err := db.TableColumn.Query().Where(
-				tablecolumn.HasTablemetaWith(tablemeta.Nanoid(tb.Nanoid)),
-				tablecolumn.Or(
-					tablecolumn.Name(c),
-					tablecolumn.Nanoid(c),
-				)).Only(ctx)
-			if err != nil {
-				if ent.IsNotFound(err) {
-					return nil, ErrColumnNotFound(c)
-				}
-				return nil, err
-			}
-			ls.ContextColumns[i] = col.Nanoid
-		}
 		s = &ls
 	}
 	return s, nil

--- a/services/table/source/validate_test.go
+++ b/services/table/source/validate_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Yiling-J/tablepilot/ent/tablecolumn"
 	"github.com/Yiling-J/tablepilot/infra/db"
 
 	"github.com/stretchr/testify/require"
@@ -18,11 +17,6 @@ func TestSource_ValidateLinked(t *testing.T) {
 	}{
 		{`{"type":"linked","table":""}`, ErrTableNameOrIdEmpty()},
 		{`{"type":"linked","table":"abc"}`, ErrTableNotFound("abc")},
-		{`{"type":"linked","table":"table"}`, ErrColumnNameOrIdEmpty()},
-		{`{"type":"linked","table":"table","column":"abc"}`, ErrColumnNotFound("abc")},
-		{`{"type":"linked","table":"table","column":"col1"}`, nil},
-		{`{"type":"linked","table":"table","column":"col1","context_columns":["abc"]}`, ErrColumnNotFound("abc")},
-		{`{"type":"linked","table":"table","column":"col1","context_columns":["col1"]}`, nil},
 	}
 
 	for _, c := range cases {
@@ -31,18 +25,12 @@ func TestSource_ValidateLinked(t *testing.T) {
 			db := db.NewTestDB()
 			tb, err := db.TableMeta.Create().SetName("table").Save(ctx)
 			require.NoError(t, err)
-			col, err := db.TableColumn.Create().SetTablemeta(tb).SetName("col1").SetFillMode(tablecolumn.FillModeAi).SetType(tablecolumn.TypeInteger).Save(ctx)
-			require.NoError(t, err)
 
 			s, err := ValidateSource(ctx, []byte(c.source), db)
 			require.Equal(t, c.error, err)
 			if err == nil {
 				st := s.(*LinkedSource)
 				require.Equal(t, tb.Nanoid, st.Table)
-				require.Equal(t, col.Nanoid, st.Column)
-				if len(st.ContextColumns) > 0 {
-					require.Equal(t, col.Nanoid, st.ContextColumns[0])
-				}
 			}
 		})
 	}

--- a/services/table/table.go
+++ b/services/table/table.go
@@ -80,18 +80,22 @@ func (t *TableServiceImpl) CreateTable(ctx context.Context, req *TableGenRequest
 	if req.Name == "" {
 		return "", ent.Rollback(tx, errors.New("table name is empty"))
 	}
-	sources := map[string]source.Source{}
+	sources := map[string]json.RawMessage{}
 	if len(req.Sources) > 0 {
 		for _, raw := range req.Sources {
-			s, err := source.ValidateSource(ctx, raw, tx.Client())
+			vs, err := source.ValidateSource(ctx, raw, tx.Client())
 			if err != nil {
 				return "", ent.Rollback(tx, err)
 			}
-			sources[gjson.GetBytes(raw, "name").String()] = s
+			bs, err := json.Marshal(vs)
+			if err != nil {
+				return "", ent.Rollback(tx, err)
+			}
+			sources[gjson.GetBytes(raw, "name").String()] = bs
 		}
 	}
 
-	table, err := tx.TableMeta.Create().SetName(req.Name).SetDescription(req.Description).SetModel(req.Model).Save(ctx)
+	table, err := tx.TableMeta.Create().SetName(req.Name).SetDescription(req.Description).SetModel(req.Model).SetSources(sources).Save(ctx)
 	if err != nil {
 		return "", ent.Rollback(tx, err)
 	}
@@ -158,12 +162,10 @@ func (t *TableServiceImpl) CreateTable(ctx context.Context, req *TableGenRequest
 			SetContextLength(col.ContextLength)
 
 		if col.Source != "" && col.FillMode == "pick" {
-			if s, ok := sources[col.Source]; ok {
-				v, err := json.Marshal(s)
-				if err != nil {
-					return "", ent.Rollback(tx, err)
-				}
-				cc.SetSource(v)
+			if _, ok := sources[col.Source]; ok {
+				cc.SetSource(col.Source).SetRandom(col.Random).
+					SetReplacement(col.Replacement).
+					SetRepeat(col.Repeat)
 			} else {
 				return "", ent.Rollback(tx, fmt.Errorf("source %s not dound", col.Source))
 			}

--- a/services/table/table.go
+++ b/services/table/table.go
@@ -172,7 +172,8 @@ func (t *TableServiceImpl) CreateTable(ctx context.Context, req *TableGenRequest
 			if _, ok := sources[col.Source]; ok {
 				cc.SetSource(col.Source).SetRandom(col.Random).
 					SetReplacement(col.Replacement).
-					SetRepeat(col.Repeat)
+					SetRepeat(col.Repeat).SetLinkedColumn(col.LinkedColumn).
+					SetLinkedContextColumns(col.LinkedContextColumns)
 			} else {
 				return "", ent.Rollback(tx, fmt.Errorf("source %s not dound", col.Source))
 			}

--- a/services/table/table.go
+++ b/services/table/table.go
@@ -99,6 +99,13 @@ func (t *TableServiceImpl) CreateTable(ctx context.Context, req *TableGenRequest
 	if err != nil {
 		return "", ent.Rollback(tx, err)
 	}
+
+	// validate linked column column/context_columns exists
+	err = validateLinkedColumnInfo(ctx, tx, req.Columns, sources)
+	if err != nil {
+		return "", ent.Rollback(tx, err)
+	}
+
 	extra := 0
 	columns := []TableGenColumn{}
 	for _, col := range req.Columns {

--- a/services/table/table_test.go
+++ b/services/table/table_test.go
@@ -76,7 +76,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		},
 		{
 			Name: "user", Description: "recipe user", Type: "boolean",
-			FillMode: "pick", Source: "users",
+			FillMode: "pick", Source: "users", LinkedColumn: "name", LinkedContextColumns: []string{"age"},
 		},
 		{},
 	}
@@ -126,8 +126,6 @@ func TestTableService_CreateTable(t *testing.T) {
       "name": "users",
       "type": "linked",
       "table": "user",
-      "column": "name",
-      "context_columns": ["age"],
       "filters": { "must": [{ "name": "a" }, { "age": 12 }, { "should": [] }] },
       "sorts": [{ "column": "name", "desc": true }]
     }
@@ -136,7 +134,7 @@ func TestTableService_CreateTable(t *testing.T) {
 
 	userTable, err := db.TableMeta.Create().SetName("user").Save(ctx)
 	require.NoError(t, err)
-	userColumns, err := db.TableColumn.CreateBulk(
+	_, err = db.TableColumn.CreateBulk(
 		db.TableColumn.Create().SetTablemeta(userTable).SetName("name").SetType(
 			tablecolumn.TypeString,
 		).SetFillMode(tablecolumn.FillModeAi),
@@ -149,7 +147,7 @@ func TestTableService_CreateTable(t *testing.T) {
 	savedSources := map[string]json.RawMessage{
 		"countries": []byte(`{"type":"list","options":["China","Japan","England","Thai","France"]}`),
 		"tags":      []byte(`{"type":"ai","prompt":"Generate 20 tags.","options":null}`),
-		"users":     []byte(fmt.Sprintf(`{"type":"linked","table":"%s","column":"%s","context_columns":["%s"]}`, userTable.Nanoid, userColumns[0].Nanoid, userColumns[1].Nanoid)),
+		"users":     []byte(fmt.Sprintf(`{"type":"linked","table":"%s"}`, userTable.Nanoid)),
 	}
 
 	id, err := srv.CreateTable(ctx, &TableGenRequest{

--- a/services/table/table_test.go
+++ b/services/table/table_test.go
@@ -34,6 +34,8 @@ func requireColumnEqual(t *testing.T, expcted, column *ent.TableColumn) {
 		require.Equal(t, expcted.Random, column.Random)
 		require.Equal(t, expcted.Replacement, column.Replacement)
 		require.Equal(t, expcted.Repeat, column.Repeat)
+		require.Equal(t, expcted.LinkedColumn, column.LinkedColumn)
+		require.Equal(t, expcted.LinkedContextColumns, column.LinkedContextColumns)
 	}
 	require.Equal(t, expcted.ContextLength, column.ContextLength)
 }
@@ -204,7 +206,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		&ent.TableColumn{
 			Name: "user", Description: "recipe user", ContextLength: 0,
 			Type: tablecolumn.TypeBoolean, FillMode: tablecolumn.FillModePick,
-			Source: "users",
+			Source: "users", LinkedColumn: "name", LinkedContextColumns: []string{"age"},
 		},
 		table.Edges.Columns[4],
 	)

--- a/services/table/table_test.go
+++ b/services/table/table_test.go
@@ -29,10 +29,11 @@ func requireColumnEqual(t *testing.T, expcted, column *ent.TableColumn) {
 	require.Equal(t, expcted.Description, column.Description)
 	require.Equal(t, expcted.Type, column.Type)
 	require.Equal(t, expcted.FillMode, column.FillMode)
-	if len(expcted.Source) > 0 {
-		require.JSONEq(t, string(expcted.Source), string(column.Source))
-	} else {
-		require.Equal(t, expcted.Source, column.Source)
+	require.Equal(t, expcted.Source, column.Source)
+	if column.Source != "" {
+		require.Equal(t, expcted.Random, column.Random)
+		require.Equal(t, expcted.Replacement, column.Replacement)
+		require.Equal(t, expcted.Repeat, column.Repeat)
 	}
 	require.Equal(t, expcted.ContextLength, column.ContextLength)
 }
@@ -67,7 +68,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		},
 		{
 			Name: "tag", Description: "recipe tag", Type: "array",
-			FillMode: "pick", Source: "tags",
+			FillMode: "pick", Source: "tags", Random: true, Replacement: true, Repeat: 3,
 		},
 		{
 			Name: "country", Description: "recipe country", Type: "string",
@@ -112,16 +113,13 @@ func TestTableService_CreateTable(t *testing.T) {
 		[]byte(`{
       "name": "countries",
       "type": "list",
-      "options": ["China", "Japan", "England", "Thai", "France"],
-      "random": true,
-      "replacement": true
+      "options": ["China", "Japan", "England", "Thai", "France"]
     }`),
 		[]byte(`
     {
       "name": "tags",
       "type": "ai",
-      "prompt": "Generate 20 tags.",
-      "random": true
+      "prompt": "Generate 20 tags."
     }`),
 		[]byte(`
     {
@@ -131,9 +129,7 @@ func TestTableService_CreateTable(t *testing.T) {
       "column": "name",
       "context_columns": ["age"],
       "filters": { "must": [{ "name": "a" }, { "age": 12 }, { "should": [] }] },
-      "sorts": [{ "column": "name", "desc": true }],
-      "random": true,
-      "replacement": true
+      "sorts": [{ "column": "name", "desc": true }]
     }
 `),
 	}
@@ -150,30 +146,10 @@ func TestTableService_CreateTable(t *testing.T) {
 	).Save(ctx)
 	require.NoError(t, err)
 
-	savedSources := []json.RawMessage{
-		[]byte(`{
-      "type": "list",
-      "options": ["China", "Japan", "England", "Thai", "France"],
-      "random": true,
-      "replacement": true
-    }`),
-		[]byte(`
-    {
-      "type": "ai",
-      "prompt": "Generate 20 tags.",
-      "random": true,
-      "options": null
-    }`),
-		[]byte(fmt.Sprintf(`
-    {
-      "type": "linked",
-      "table": "%s",
-      "column": "%s",
-      "context_columns": ["%s"],
-      "random": true,
-      "replacement": true
-    }
-`, userTable.Nanoid, userColumns[0].Nanoid, userColumns[1].Nanoid)),
+	savedSources := map[string]json.RawMessage{
+		"countries": []byte(`{"type":"list","options":["China","Japan","England","Thai","France"]}`),
+		"tags":      []byte(`{"type":"ai","prompt":"Generate 20 tags.","options":null}`),
+		"users":     []byte(fmt.Sprintf(`{"type":"linked","table":"%s","column":"%s","context_columns":["%s"]}`, userTable.Nanoid, userColumns[0].Nanoid, userColumns[1].Nanoid)),
 	}
 
 	id, err := srv.CreateTable(ctx, &TableGenRequest{
@@ -190,11 +166,12 @@ func TestTableService_CreateTable(t *testing.T) {
 	require.Equal(t, "test table", table.Description)
 	require.Equal(t, id, table.Nanoid)
 	require.Equal(t, 6, len(table.Edges.Columns))
+	require.Equal(t, savedSources, table.Sources)
 	requireColumnEqual(
 		t,
 		&ent.TableColumn{
 			Name: "name", Description: "recipe name", ContextLength: 5,
-			Type: tablecolumn.TypeString, FillMode: tablecolumn.FillModeAi, Source: nil,
+			Type: tablecolumn.TypeString, FillMode: tablecolumn.FillModeAi, Source: "",
 		},
 		table.Edges.Columns[0],
 	)
@@ -202,7 +179,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		t,
 		&ent.TableColumn{
 			Name: "count", Description: "recipe count", ContextLength: 3,
-			Type: tablecolumn.TypeInteger, FillMode: tablecolumn.FillModeAi, Source: nil,
+			Type: tablecolumn.TypeInteger, FillMode: tablecolumn.FillModeAi, Source: "",
 		},
 		table.Edges.Columns[1],
 	)
@@ -211,7 +188,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		&ent.TableColumn{
 			Name: "tag", Description: "recipe tag", ContextLength: 0,
 			Type: tablecolumn.TypeArray, FillMode: tablecolumn.FillModePick,
-			Source: savedSources[1],
+			Source: "tags", Random: true, Replacement: true, Repeat: 3,
 		},
 		table.Edges.Columns[2],
 	)
@@ -220,7 +197,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		&ent.TableColumn{
 			Name: "country", Description: "recipe country", ContextLength: 0,
 			Type: tablecolumn.TypeString, FillMode: tablecolumn.FillModePick,
-			Source: savedSources[0],
+			Source: "countries",
 		},
 		table.Edges.Columns[3],
 	)
@@ -229,7 +206,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		&ent.TableColumn{
 			Name: "user", Description: "recipe user", ContextLength: 0,
 			Type: tablecolumn.TypeBoolean, FillMode: tablecolumn.FillModePick,
-			Source: savedSources[2],
+			Source: "users",
 		},
 		table.Edges.Columns[4],
 	)

--- a/services/table/validate.go
+++ b/services/table/validate.go
@@ -1,0 +1,62 @@
+package table
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Yiling-J/tablepilot/ent"
+	"github.com/Yiling-J/tablepilot/ent/tablecolumn"
+	"github.com/Yiling-J/tablepilot/ent/tablemeta"
+	"github.com/tidwall/gjson"
+)
+
+func ErrColumnNotFound(input string) error {
+	return fmt.Errorf("Column not found: %s", input)
+}
+
+func validateLinkedColumnInfo(ctx context.Context, tx *ent.Tx, columns []TableGenColumn, sources map[string]json.RawMessage) error {
+	// validate linked column column/context_columns exists
+	for _, col := range columns {
+		if col.FillMode != "pick" {
+			continue
+		}
+		source, ok := sources[col.Source]
+		if !ok {
+			return fmt.Errorf("source %s not found", col.Source)
+		}
+		if gjson.GetBytes(source, "type").String() != "linked" {
+			continue
+		}
+		table := gjson.GetBytes(source, "table").String()
+		linkedTable, err := tx.TableMeta.Query().WithColumns(func(tcq *ent.TableColumnQuery) {
+			tcq.Order(ent.Asc(tablecolumn.FieldID))
+		}).Where(tablemeta.Or(
+			tablemeta.Nanoid(table),
+			tablemeta.Name(table),
+		)).First(ctx)
+		if err != nil {
+			return err
+		}
+
+		names := map[string]bool{}
+		ids := map[string]bool{}
+
+		for _, dbcol := range linkedTable.Edges.Columns {
+			names[dbcol.Name] = true
+			ids[dbcol.Nanoid] = true
+		}
+
+		if !names[col.LinkedColumn] && !ids[col.LinkedColumn] {
+			return ErrColumnNotFound(col.LinkedColumn)
+		}
+		if len(col.LinkedContextColumns) > 0 {
+			for _, lc := range col.LinkedContextColumns {
+				if !names[lc] && !ids[lc] {
+					return ErrColumnNotFound(lc)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/services/table/validate_test.go
+++ b/services/table/validate_test.go
@@ -1,0 +1,51 @@
+package table
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/Yiling-J/tablepilot/ent/tablecolumn"
+	"github.com/Yiling-J/tablepilot/infra/db"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableService_ValidateLinkedColumnInfo(t *testing.T) {
+	cases := []struct {
+		column TableGenColumn
+		error  error
+	}{
+		{TableGenColumn{LinkedColumn: "abc"}, ErrColumnNotFound("abc")},
+		{TableGenColumn{LinkedColumn: "col1"}, nil},
+		{TableGenColumn{LinkedColumn: "__id__"}, nil},
+		{TableGenColumn{LinkedColumn: "col1", LinkedContextColumns: []string{"abc"}}, ErrColumnNotFound("abc")},
+		{TableGenColumn{LinkedColumn: "col1", LinkedContextColumns: []string{"col1"}}, nil},
+		{TableGenColumn{LinkedColumn: "col1", LinkedContextColumns: []string{"__id__"}}, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%+v", c), func(t *testing.T) {
+			ctx := context.TODO()
+			db := db.NewTestDB()
+			tx, _ := db.Tx(ctx)
+			tb, err := tx.TableMeta.Create().SetName("table").Save(ctx)
+			require.NoError(t, err)
+			col, err := tx.TableColumn.Create().SetTablemeta(tb).SetName("col1").SetFillMode(tablecolumn.FillModeAi).SetType(tablecolumn.TypeInteger).Save(ctx)
+			require.NoError(t, err)
+			if c.column.LinkedColumn == "__id__" {
+				c.column.LinkedColumn = col.Nanoid
+			}
+			for i, cc := range c.column.LinkedContextColumns {
+				if cc == "__id__" {
+					c.column.LinkedContextColumns[i] = col.Nanoid
+				}
+			}
+			c.column.FillMode = "pick"
+			c.column.Source = "so"
+			err = validateLinkedColumnInfo(ctx, tx, []TableGenColumn{c.column}, map[string]json.RawMessage{"so": []byte(`{"type":"linked","table":"table"}`)})
+			require.Equal(t, c.error, err)
+		})
+	}
+}

--- a/ui/src/actions.ts
+++ b/ui/src/actions.ts
@@ -88,9 +88,6 @@ export async function getTable(id: string): Promise<TableInfo> {
 interface BaseSource {
   name: string;
   type: string;
-  random: boolean;
-  replacement: boolean;
-  repeat: number;
 }
 
 export interface AiSource extends BaseSource {
@@ -123,6 +120,9 @@ export interface TableCreateRequest {
     fill_mode: string;
     context_length?: number;
     source?: string;
+    random: boolean;
+    replacement: boolean;
+    repeat: number;
   }[];
 }
 

--- a/ui/src/actions.ts
+++ b/ui/src/actions.ts
@@ -103,8 +103,6 @@ export interface ListSource extends BaseSource {
 export interface LinkedSource extends BaseSource {
   type: "linked";
   table: string;
-  column: string;
-  context_columns: string[];
 }
 
 export type Source = AiSource | ListSource | LinkedSource;
@@ -123,6 +121,8 @@ export interface TableCreateRequest {
     random: boolean;
     replacement: boolean;
     repeat: number;
+    linked_column: string;
+    linked_context_columns: string[];
   }[];
 }
 

--- a/ui/src/components/create-table-form/columns-form.tsx
+++ b/ui/src/components/create-table-form/columns-form.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { NumberInput } from "@/components/ui/number-input";
 import {
     Select,
     SelectContent,
@@ -21,6 +22,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Edit, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -46,6 +48,9 @@ export function ColumnsForm({
   const [source, setSource] = useState<string | undefined>(undefined);
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [random, setRandom] = useState(true);
+  const [replacement, setReplacement] = useState(false);
+  const [repeat, setRepeat] = useState(1);
 
   const resetForm = () => {
     setColumnName("");
@@ -55,6 +60,9 @@ export function ColumnsForm({
     setContextLength(undefined);
     setSource(undefined);
     setEditIndex(null);
+    setRandom(true);
+    setReplacement(false);
+    setRepeat(1);
   };
 
   const handleAddColumn = () => {
@@ -63,6 +71,9 @@ export function ColumnsForm({
       description: columnDescription,
       type: columnType,
       fill_mode: fillMode,
+      random: random,
+      replacement: replacement,
+      repeat: repeat,
       ...(contextLength ? { context_length: contextLength } : {}),
       ...(source ? { source } : {}),
     };
@@ -89,6 +100,9 @@ export function ColumnsForm({
     setContextLength(column.context_length);
     setSource(column.source);
     setEditIndex(index);
+    setRandom(column.random);
+    setReplacement(column.replacement);
+    setRepeat(column.repeat);
     setIsDialogOpen(true);
   };
 
@@ -217,6 +231,34 @@ export function ColumnsForm({
                       ))}
                     </SelectContent>
                   </Select>
+                  <div className="flex items-center space-x-2 pt-2">
+                    <Switch
+                      id="random"
+                      checked={random}
+                      onCheckedChange={setRandom}
+                    />
+                    <Label htmlFor="random">Random Selection</Label>
+                  </div>
+
+                  <div className="flex items-center space-x-2 pt-2">
+                    <Switch
+                      id="replacement"
+                      checked={replacement}
+                      onCheckedChange={setReplacement}
+                    />
+                    <Label htmlFor="replacement">
+                      Selection with Replacement
+                    </Label>
+                  </div>
+
+                  <div className="flex items-center space-x-2 pt-2">
+                    <NumberInput
+                      id="repeat"
+                      value={repeat > 0 ? repeat : 1}
+                      onValueChange={(v) => setRepeat(v ?? 1)}
+                    />
+                    <Label htmlFor="reppeat">Repeat selection</Label>
+                  </div>
                   {formData.sources.length === 0 && (
                     <p className="text-xs text-muted-foreground mt-1">
                       Add sources in the previous step to use this fill mode

--- a/ui/src/components/create-table-form/columns-form.tsx
+++ b/ui/src/components/create-table-form/columns-form.tsx
@@ -1,8 +1,21 @@
-"use client";
-
-import { TableCreateRequest } from "@/actions";
+import {
+    Column,
+    LinkedSource,
+    TableCreateRequest,
+    TableInfo,
+    getTables,
+} from "@/actions";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command";
 import {
     Dialog,
     DialogContent,
@@ -16,6 +29,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { NumberInput } from "@/components/ui/number-input";
 import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover";
+import {
     Select,
     SelectContent,
     SelectItem,
@@ -24,8 +42,9 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { Edit, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Check, ChevronsUpDown, Edit, Plus, Trash2, X } from "lucide-react";
+import { useEffect, useState } from "react";
 
 interface ColumnsFormProps {
   formData: TableCreateRequest;
@@ -51,6 +70,14 @@ export function ColumnsForm({
   const [random, setRandom] = useState(true);
   const [replacement, setReplacement] = useState(false);
   const [repeat, setRepeat] = useState(1);
+  const [selectedColumn, setSelectedColumn] = useState<string>("");
+  const [tables, setTables] = useState<TableInfo[]>([]);
+  const [linkedTableColumns, setLinkedTableColumns] = useState<Column[]>([]);
+  const [selectedContextColumns, setSelectedContextColumns] = useState<
+    string[]
+  >([]);
+  const [openContextColumnsPopover, setOpenContextColumnsPopover] =
+    useState(false);
 
   const resetForm = () => {
     setColumnName("");
@@ -63,6 +90,24 @@ export function ColumnsForm({
     setRandom(true);
     setReplacement(false);
     setRepeat(1);
+    setSelectedColumn("");
+    setSelectedContextColumns([]);
+  };
+
+  useEffect(() => {
+    if (tables.length === 0) {
+      fetchTables();
+    }
+  }, []);
+
+  // Fetch tables from API
+  const fetchTables = async () => {
+    try {
+      const resp = await getTables();
+      setTables(resp.tables);
+    } catch (error) {
+      console.error("Error fetching tables:", error);
+    }
   };
 
   const handleAddColumn = () => {
@@ -74,6 +119,8 @@ export function ColumnsForm({
       random: random,
       replacement: replacement,
       repeat: repeat,
+      linked_column: selectedColumn,
+      linked_context_columns: selectedContextColumns,
       ...(contextLength ? { context_length: contextLength } : {}),
       ...(source ? { source } : {}),
     };
@@ -103,7 +150,35 @@ export function ColumnsForm({
     setRandom(column.random);
     setReplacement(column.replacement);
     setRepeat(column.repeat);
+    setSelectedColumn(column.linked_column);
+    setSelectedContextColumns(column.linked_context_columns || []);
+    if (column.source) {
+      const source = formData.sources.find((s) => s.name == column.source);
+      if (source && source.type === "linked") {
+        const linkedSource = source as LinkedSource;
+        const table = tables.find((t) => t.name === linkedSource.table);
+        if (table) {
+          setLinkedTableColumns(table.columns);
+        }
+      }
+    }
     setIsDialogOpen(true);
+  };
+
+  const handleSelectSource = (source: string | undefined) => {
+    setSource(source);
+    setSelectedColumn("");
+    setSelectedContextColumns([]);
+    if (source) {
+      const ls = formData.sources.find((s) => s.name === source);
+      if (ls && ls.type === "linked") {
+        const linkedSource = ls as LinkedSource;
+        const table = tables.find((t) => t.name === linkedSource.table);
+        if (table) {
+          setLinkedTableColumns(table.columns);
+        }
+      }
+    }
   };
 
   const handleDeleteColumn = (index: number) => {
@@ -127,7 +202,7 @@ export function ColumnsForm({
               <Plus className="mr-2 h-4 w-4" /> Add Column
             </Button>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-[500px]">
+          <DialogContent className="sm:max-w-[530px] scrollbar-thumb-rounded-full scrollbar-track-rounded-full scrollbar scrollbar-thumb-stone-500 scrollbar-track-background">
             <DialogHeader>
               <DialogTitle>
                 {editIndex !== null ? "Edit Column" : "Add New Column"}
@@ -136,7 +211,7 @@ export function ColumnsForm({
                 Define a column for your table
               </DialogDescription>
             </DialogHeader>
-            <div className="grid gap-4 py-4">
+            <div className="grid gap-4 py-4 px-2 max-h-[65vh] overflow-auto scrollbar-thin">
               <div className="grid gap-2">
                 <Label htmlFor="columnName">Column Name</Label>
                 <Input
@@ -180,7 +255,6 @@ export function ColumnsForm({
                   <SelectContent>
                     <SelectItem value="ai">AI Generated</SelectItem>
                     <SelectItem value="pick">Pick from Source</SelectItem>
-                    <SelectItem value="user">User Input</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -211,7 +285,7 @@ export function ColumnsForm({
                   <Label htmlFor="source">Source</Label>
                   <Select
                     value={source}
-                    onValueChange={setSource}
+                    onValueChange={handleSelectSource}
                     disabled={formData.sources.length === 0}
                   >
                     <SelectTrigger>
@@ -231,6 +305,128 @@ export function ColumnsForm({
                       ))}
                     </SelectContent>
                   </Select>
+
+                  {formData.sources.find((s) => s.name === source)?.type ===
+                    "linked" && (
+                    <>
+                      <div className="grid gap-2 pt-2">
+                        <Label htmlFor="column">Linked Column</Label>
+                        <Select
+                          value={selectedColumn}
+                          onValueChange={setSelectedColumn}
+                          disabled={linkedTableColumns.length === 0}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a column" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {linkedTableColumns.map((column) => (
+                              <SelectItem key={column.id} value={column.name}>
+                                {column.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div className="grid gap-2 pt-2">
+                        <Label>Linked Context Columns</Label>
+                        <Popover
+                          open={openContextColumnsPopover}
+                          onOpenChange={setOpenContextColumnsPopover}
+                        >
+                          <PopoverTrigger asChild>
+                            <Button
+                              variant="outline"
+                              role="combobox"
+                              aria-expanded={openContextColumnsPopover}
+                              className="justify-between h-auto min-h-10"
+                            >
+                              {selectedContextColumns.length > 0 ? (
+                                <div className="flex flex-wrap gap-1">
+                                  {selectedContextColumns.map((column) => (
+                                    <Badge
+                                      key={column}
+                                      variant="secondary"
+                                      className="mr-1 mb-1"
+                                    >
+                                      {column}
+                                      <button
+                                        className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                                        onKeyDown={(e) => {
+                                          if (e.key === "Enter") {
+                                            setSelectedContextColumns(
+                                              selectedContextColumns.filter(
+                                                (c) => c !== column,
+                                              ),
+                                            );
+                                          }
+                                        }}
+                                        onMouseDown={(e) => {
+                                          e.preventDefault();
+                                          e.stopPropagation();
+                                          setSelectedContextColumns(
+                                            selectedContextColumns.filter(
+                                              (c) => c !== column,
+                                            ),
+                                          );
+                                        }}
+                                      >
+                                        <X className="h-3 w-3" />
+                                      </button>
+                                    </Badge>
+                                  ))}
+                                </div>
+                              ) : (
+                                "Select context columns"
+                              )}
+                              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                            </Button>
+                          </PopoverTrigger>
+                          <PopoverContent className="p-0 w-[300px]">
+                            <Command>
+                              <CommandInput placeholder="Search columns..." />
+                              <CommandList>
+                                <CommandEmpty>No columns found.</CommandEmpty>
+                                <CommandGroup>
+                                  {linkedTableColumns.map((column) => (
+                                    <CommandItem
+                                      key={column.id}
+                                      value={column.name}
+                                      onSelect={() => {
+                                        setSelectedContextColumns((prev) =>
+                                          prev.includes(column.name)
+                                            ? prev.filter(
+                                                (c) => c !== column.name,
+                                              )
+                                            : [...prev, column.name],
+                                        );
+                                      }}
+                                    >
+                                      <div
+                                        className={cn(
+                                          "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
+                                          selectedContextColumns.includes(
+                                            column.name,
+                                          )
+                                            ? "bg-primary text-primary-foreground"
+                                            : "opacity-50 [&_svg]:invisible",
+                                        )}
+                                      >
+                                        <Check className="h-4 w-4" />
+                                      </div>
+                                      {column.name}
+                                    </CommandItem>
+                                  ))}
+                                </CommandGroup>
+                              </CommandList>
+                            </Command>
+                          </PopoverContent>
+                        </Popover>
+                      </div>
+                    </>
+                  )}
+
                   <div className="flex items-center space-x-2 pt-2">
                     <Switch
                       id="random"
@@ -315,7 +511,7 @@ export function ColumnsForm({
                   </div>
                 </div>
               </CardHeader>
-              <CardContent className="py-2 px-6">
+              <CardContent className="pt-0 pb-2 px-6">
                 <div className="text-sm">
                   <div className="mb-1">{column.description}</div>
                   <div className="flex gap-4 mt-2 text-xs text-muted-foreground">

--- a/ui/src/components/create-table-form/columns-form.tsx
+++ b/ui/src/components/create-table-form/columns-form.tsx
@@ -351,7 +351,10 @@ export function ColumnsForm({
                                       className="mr-1 mb-1"
                                     >
                                       {column}
-                                      <button
+                                      <Button
+                                        asChild
+                                        variant="ghost"
+                                        size="icon"
                                         className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                                         onKeyDown={(e) => {
                                           if (e.key === "Enter") {
@@ -372,8 +375,8 @@ export function ColumnsForm({
                                           );
                                         }}
                                       >
-                                        <X className="h-3 w-3" />
-                                      </button>
+                                        <X className="h-4 w-4" />
+                                      </Button>
                                     </Badge>
                                   ))}
                                 </div>

--- a/ui/src/components/create-table-form/create-table-form.tsx
+++ b/ui/src/components/create-table-form/create-table-form.tsx
@@ -89,7 +89,7 @@ export default function CreateTableForm({
   const isStep3Valid = formData.columns.length > 0;
 
   return (
-    <div className="mx-0 scrollbar-thumb-rounded-full scrollbar-track-rounded-full scrollbar scrollbar-thumb-stone-500 scrollbar-track-background">
+    <div className="mx-0">
       <div
         className={cn(
           "container mx-auto py-2 px-2 overflow-y-auto scrollbar-thin grow pl-3",

--- a/ui/src/components/create-table-form/sources-form.tsx
+++ b/ui/src/components/create-table-form/sources-form.tsx
@@ -1,6 +1,5 @@
 import {
     AiSource,
-    Column,
     LinkedSource,
     ListSource,
     Source,
@@ -8,17 +7,9 @@ import {
     TableInfo,
     getTables,
 } from "@/actions";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-    Command,
-    CommandEmpty,
-    CommandGroup,
-    CommandInput,
-    CommandItem,
-    CommandList,
-} from "@/components/ui/command";
+
 import {
     Dialog,
     DialogContent,
@@ -30,11 +21,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from "@/components/ui/popover";
+
 import {
     Select,
     SelectContent,
@@ -43,8 +30,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { cn } from "@/lib/utils";
-import { Check, ChevronsUpDown, Edit, Plus, Trash2, X } from "lucide-react";
+import { Edit, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 interface SourcesFormProps {
@@ -69,13 +55,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
   const [tables, setTables] = useState<TableInfo[]>([]);
   const [isLoadingTables, setIsLoadingTables] = useState(false);
   const [selectedTable, setSelectedTable] = useState<string>("");
-  const [tableColumns, setTableColumns] = useState<Column[]>([]);
-  const [selectedColumn, setSelectedColumn] = useState<string>("");
-  const [selectedContextColumns, setSelectedContextColumns] = useState<
-    string[]
-  >([]);
-  const [openContextColumnsPopover, setOpenContextColumnsPopover] =
-    useState(false);
 
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -104,10 +83,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
     const table = tables.find((t) => t.name === selected);
     if (table) {
       setSelectedTable(selected);
-      setTableColumns(table.columns);
-      // Reset column selections when table changes
-      setSelectedColumn("");
-      setSelectedContextColumns([]);
     }
   };
 
@@ -118,9 +93,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
     setOptions("");
     // Reset linked source fields
     setSelectedTable("");
-    setSelectedColumn("");
-    setSelectedContextColumns([]);
-    setTableColumns([]);
     setEditIndex(null);
   };
 
@@ -144,8 +116,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
         name: sourceName,
         type: "linked",
         table: selectedTable,
-        column: selectedColumn,
-        context_columns: selectedContextColumns,
       };
     }
 
@@ -176,14 +146,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
     } else if (source.type === "linked") {
       const linkedSource = source as LinkedSource;
       setSelectedTable(linkedSource.table);
-      setSelectedColumn(linkedSource.column);
-      setSelectedContextColumns(linkedSource.context_columns || []);
-
-      // Set table columns based on the selected table
-      const table = tables.find((t) => t.name === linkedSource.table);
-      if (table) {
-        setTableColumns(table.columns);
-      }
     }
 
     setEditIndex(index);
@@ -200,8 +162,7 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
 
     if (sourceType === "ai" && !prompt) return false;
     if (sourceType === "list" && !options) return false;
-    if (sourceType === "linked" && (!selectedTable || !selectedColumn))
-      return false;
+    if (sourceType === "linked" && !selectedTable) return false;
 
     return true;
   };
@@ -235,17 +196,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
             <span className="font-medium">Table:</span>
             <span>{linkedSource.table}</span>
           </div>
-          <div className="flex gap-2 mb-1">
-            <span className="font-medium">Column:</span>
-            <span>{linkedSource.column}</span>
-          </div>
-          {linkedSource.context_columns &&
-            linkedSource.context_columns.length > 0 && (
-              <div className="flex gap-2 mb-1">
-                <span className="font-medium">Context Columns:</span>
-                <span>{linkedSource.context_columns.join(", ")}</span>
-              </div>
-            )}
         </>
       );
     }
@@ -357,130 +307,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
                       </SelectContent>
                     </Select>
                   </div>
-
-                  {selectedTable && (
-                    <>
-                      <div className="grid gap-2">
-                        <Label htmlFor="column">Select Column</Label>
-                        <Select
-                          value={selectedColumn}
-                          onValueChange={setSelectedColumn}
-                          disabled={tableColumns.length === 0}
-                        >
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select a column" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {tableColumns.map((column) => (
-                              <SelectItem key={column.id} value={column.name}>
-                                {column.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-
-                      <div className="grid gap-2">
-                        <Label>Context Columns</Label>
-                        <Popover
-                          open={openContextColumnsPopover}
-                          onOpenChange={setOpenContextColumnsPopover}
-                        >
-                          <PopoverTrigger asChild>
-                            <Button
-                              variant="outline"
-                              role="combobox"
-                              aria-expanded={openContextColumnsPopover}
-                              className="justify-between h-auto min-h-10"
-                            >
-                              {selectedContextColumns.length > 0 ? (
-                                <div className="flex flex-wrap gap-1">
-                                  {selectedContextColumns.map((column) => (
-                                    <Badge
-                                      key={column}
-                                      variant="secondary"
-                                      className="mr-1 mb-1"
-                                    >
-                                      {column}
-                                      <button
-                                        className="ml-1 ring-offset-background rounded-full outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                                        onKeyDown={(e) => {
-                                          if (e.key === "Enter") {
-                                            setSelectedContextColumns(
-                                              selectedContextColumns.filter(
-                                                (c) => c !== column,
-                                              ),
-                                            );
-                                          }
-                                        }}
-                                        onMouseDown={(e) => {
-                                          e.preventDefault();
-                                          e.stopPropagation();
-                                          setSelectedContextColumns(
-                                            selectedContextColumns.filter(
-                                              (c) => c !== column,
-                                            ),
-                                          );
-                                        }}
-                                      >
-                                        <X className="h-3 w-3" />
-                                      </button>
-                                    </Badge>
-                                  ))}
-                                </div>
-                              ) : (
-                                "Select context columns"
-                              )}
-                              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                            </Button>
-                          </PopoverTrigger>
-                          <PopoverContent className="p-0 w-[300px]">
-                            <Command>
-                              <CommandInput placeholder="Search columns..." />
-                              <CommandList>
-                                <CommandEmpty>No columns found.</CommandEmpty>
-                                <CommandGroup>
-                                  {tableColumns.map((column) => (
-                                    <CommandItem
-                                      key={column.id}
-                                      value={column.name}
-                                      onSelect={() => {
-                                        setSelectedContextColumns((prev) =>
-                                          prev.includes(column.name)
-                                            ? prev.filter(
-                                                (c) => c !== column.name,
-                                              )
-                                            : [...prev, column.name],
-                                        );
-                                      }}
-                                    >
-                                      <div
-                                        className={cn(
-                                          "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
-                                          selectedContextColumns.includes(
-                                            column.name,
-                                          )
-                                            ? "bg-primary text-primary-foreground"
-                                            : "opacity-50 [&_svg]:invisible",
-                                        )}
-                                      >
-                                        <Check className="h-4 w-4" />
-                                      </div>
-                                      {column.name}
-                                    </CommandItem>
-                                  ))}
-                                </CommandGroup>
-                              </CommandList>
-                            </Command>
-                          </PopoverContent>
-                        </Popover>
-                        <p className="text-xs text-muted-foreground">
-                          Select columns to provide context when using this
-                          source
-                        </p>
-                      </div>
-                    </>
-                  )}
                 </>
               )}
             </div>
@@ -504,7 +330,7 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
         <div className="grid gap-4 mt-4">
           {formData.sources.map((source, index) => (
             <Card key={index}>
-              <CardHeader className="py-4 px-6">
+              <CardHeader className="py-1 px-6">
                 <div className="flex justify-between items-center">
                   <CardTitle className="text-base font-medium">
                     {source.name}
@@ -527,7 +353,7 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
                   </div>
                 </div>
               </CardHeader>
-              <CardContent className="py-2 px-6">
+              <CardContent className="pt-0 pb-2 px-6">
                 <div className="text-sm">
                   <div className="flex gap-2 mb-1">
                     <span className="font-medium">Type:</span>

--- a/ui/src/components/create-table-form/sources-form.tsx
+++ b/ui/src/components/create-table-form/sources-form.tsx
@@ -42,12 +42,10 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { Check, ChevronsUpDown, Edit, Plus, Trash2, X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { NumberInput } from "../ui/number-input";
 
 interface SourcesFormProps {
   formData: TableCreateRequest;
@@ -66,9 +64,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
   const [sourceType, setSourceType] = useState<SourceType>("ai");
   const [prompt, setPrompt] = useState("");
   const [options, setOptions] = useState("");
-  const [random, setRandom] = useState(true);
-  const [replacement, setReplacement] = useState(false);
-  const [repeat, setRepeat] = useState(1);
 
   // Add new state for linked source type
   const [tables, setTables] = useState<TableInfo[]>([]);
@@ -121,15 +116,12 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
     setSourceType("ai");
     setPrompt("");
     setOptions("");
-    setRandom(true);
-    setReplacement(false);
     // Reset linked source fields
     setSelectedTable("");
     setSelectedColumn("");
     setSelectedContextColumns([]);
     setTableColumns([]);
     setEditIndex(null);
-    setRepeat(1);
   };
 
   const handleAddSource = () => {
@@ -140,18 +132,12 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
         name: sourceName,
         type: "ai",
         prompt,
-        random,
-        replacement,
-        repeat,
       };
     } else if (sourceType === "list") {
       newSource = {
         name: sourceName,
         type: "list",
         options: options.split("\n").filter(Boolean),
-        random,
-        replacement,
-        repeat,
       };
     } else {
       newSource = {
@@ -160,9 +146,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
         table: selectedTable,
         column: selectedColumn,
         context_columns: selectedContextColumns,
-        random,
-        replacement,
-        repeat,
       };
     }
 
@@ -183,9 +166,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
     const source = formData.sources[index];
     setSourceName(source.name);
     setSourceType(source.type as SourceType);
-    setRandom(source.random);
-    setReplacement(source.replacement);
-    setRepeat(source.repeat);
 
     if (source.type === "ai") {
       const aiSource = source as AiSource;
@@ -503,37 +483,6 @@ export function SourcesForm({ formData, updateFormData }: SourcesFormProps) {
                   )}
                 </>
               )}
-
-              <>
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="random"
-                    checked={random}
-                    onCheckedChange={setRandom}
-                  />
-                  <Label htmlFor="random">Random Selection</Label>
-                </div>
-
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="replacement"
-                    checked={replacement}
-                    onCheckedChange={setReplacement}
-                  />
-                  <Label htmlFor="replacement">
-                    Selection with Replacement
-                  </Label>
-                </div>
-
-                <div className="flex items-center space-x-2">
-                  <NumberInput
-                    id="repeat"
-                    value={repeat > 0 ? repeat : 1}
-                    onValueChange={(v) => setRepeat(v ?? 1)}
-                  />
-                  <Label htmlFor="reppeat">Repeat selection</Label>
-                </div>
-              </>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setIsDialogOpen(false)}>

--- a/ui/src/components/dialog/create-table.tsx
+++ b/ui/src/components/dialog/create-table.tsx
@@ -33,7 +33,7 @@ export function CreateTableDialog({
         }}
       >
         <DialogTitle>Create New Table</DialogTitle>
-        <div className="mx-2 mt-2">
+        <div className="mx-2 mt-2 scrollbar-thumb-rounded-full scrollbar-track-rounded-full scrollbar scrollbar-thumb-stone-500 scrollbar-track-background">
           <CreateTableForm close={close} form={form} rows={rows} />
         </div>
       </DialogContent>

--- a/ui/src/components/dialog/import-csv.tsx
+++ b/ui/src/components/dialog/import-csv.tsx
@@ -66,6 +66,9 @@ export function ImportCSVDialog({
             description: "",
             type: "string",
             fill_mode: "ai",
+            random: true,
+            replacement: false,
+            repeat: 1,
           };
         }),
       };

--- a/ui/src/components/dialog/import-csv.tsx
+++ b/ui/src/components/dialog/import-csv.tsx
@@ -69,6 +69,8 @@ export function ImportCSVDialog({
             random: true,
             replacement: false,
             repeat: 1,
+            linked_column: "",
+            linked_context_columns: [],
           };
         }),
       };

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,17 +1,1 @@
 package utils
-
-import "github.com/gin-gonic/gin"
-
-const ctxUserKey = "ctxUserKey"
-
-func WithUserId(ctx *gin.Context, userId int) {
-	ctx.Set(ctxUserKey, userId)
-}
-
-func UserId(ctx *gin.Context) int {
-	raw, exists := ctx.Get(ctxUserKey)
-	if !exists {
-		return 0
-	}
-	return raw.(int)
-}


### PR DESCRIPTION
Currently, the `random`, `replacement`, `repeat`, `column`, and `context_columns` parameters are defined in the source schema. However, these parameters determine how values are selected from the source rather than defining the source itself. Moving them to the column schema allows multiple columns to share the same source while independently specifying how values should be selected and used.