### PR TITLE
Support Kaggle dataset in CSV source

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ To generate a table, you’ll need a **TOML config file**, and in the case of th
 
 Below is an example `config.toml` file using an SQLite3 database (`data.db`). This configuration defines two clients, **OpenAI** and **Gemini**, and assigns two models to them:  
 
-- **Gemini** → `gemini-2.0-flash-001` (default)  
-- **OpenAI** → `gpt-4o`  
+- **Gemini** → `gemini-2.0-flash-001` (default)
+- **OpenAI** → `gpt-4o`
 
-You can modify the configuration by selecting a single client/model pair, removing the other, or adjusting the settings to fit your needs.  
+You can modify the configuration by selecting a single client/model pair, removing the other, or adjusting the settings to fit your needs.
 
 Make sure to replace the `key` field with your actual OpenAI/Gemini API key before saving the file as `config.toml`.
 
@@ -323,6 +323,12 @@ Special fields for different types:
     - Full match: `"data/cuisines.csv"`
     - Single asterisk: `"data/*.csv"` (matches all CSV files in `data/`)
     - Double asterisk: `"data/**/*.csv"` (matches all CSV files in `data/` and subdirectories)
+  - **kaggle**: The kaggle dataset name, e.g., "fernandol/countries-of-the-world"
+  You can use kaggle dataset as csv data source, when you do this, Tablepilot will first download the dataset into a cache folder: {source_data_dir}/tablepilot_kaggle_cache/{dataset name(replace / to --)}. Then it works like a local csv source, the only difference is the search root for paths in related to the downloaded folder. The cache will alwasy be used unless you remove it manually. Example:
+  ```json
+  {"name": "countries", "type": "csv", "kaggle": "fernandol/countries-of-the-world", "paths": ["*.csv"]}
+  ```
+  You can find the dataset name when click the download button in the right top corner of the dataset page. 
 
 #### columns: 
 A list of column definitions. Each column is an object that can contain the following fields:

--- a/README.md
+++ b/README.md
@@ -323,12 +323,27 @@ Special fields for different types:
     - Full match: `"data/cuisines.csv"`
     - Single asterisk: `"data/*.csv"` (matches all CSV files in `data/`)
     - Double asterisk: `"data/**/*.csv"` (matches all CSV files in `data/` and subdirectories)
-  - **kaggle**: The kaggle dataset name, e.g., "fernandol/countries-of-the-world"
-  You can use kaggle dataset as csv data source, when you do this, Tablepilot will first download the dataset into a cache folder: {source_data_dir}/tablepilot_kaggle_cache/{dataset name(replace / to --)}. Then it works like a local csv source, the only difference is the search root for paths in related to the downloaded folder. The cache will alwasy be used unless you remove it manually. Example:
-  ```json
-  {"name": "countries", "type": "csv", "kaggle": "fernandol/countries-of-the-world", "paths": ["*.csv"]}
-  ```
-  You can find the dataset name when click the download button in the right top corner of the dataset page. 
+  - **kaggle**: The Kaggle dataset name, e.g., `"fernandol/countries-of-the-world"`.
+
+    You can use a Kaggle dataset as a CSV data source. When doing so, Tablepilot first downloads the dataset into a cache folder:
+
+    ```
+    {source_data_dir}/tablepilot_kaggle_cache/{dataset_name (with `/` replaced by `--`)}
+    ```
+
+    Once downloaded, it functions like a local CSV source. The only difference is that the search root for `paths` is relative to the downloaded folder. The cached dataset will always be used unless you remove it manually.
+
+    **Example:**
+    ```json
+    {
+      "name": "countries",
+      "type": "csv",
+      "kaggle": "fernandol/countries-of-the-world",
+      "paths": ["*.csv"]
+    }
+    ```
+
+    You can find the dataset name by clicking the **Download** button in the top-right corner of the dataset page on Kaggle.
 
 #### columns: 
 A list of column definitions. Each column is an object that can contain the following fields:

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,9 @@ All examples are generated using gemini-2.0-flash-001 with a tempature of 0.6.
 - **recipes_by_country**
   This example demonstrates how to repeat column values. The generated table will include 6 recipes for each country: 2 Breakfast recipes, 2 Lunch recipes, and 2 Dinner recipes.
 
+- **recipes_by_country_kaggle**
+  This example demonstrates how to use a kaggle country dataset(https://www.kaggle.com/datasets/fernandol/countries-of-the-world) as context. The generated table will include 6 recipes for each country: 2 Breakfast recipes, 2 Lunch recipes, and 2 Dinner recipes.
+
 - **recipes_for_customers**
   This is the most complex example, illustrating how to use another table as a reference. The `customers.json` file is used to generate a customer table, and then the recipes table is generated based on customer data. Each customer will receive a unique recipe tailored to their information.
   

--- a/examples/recipes_by_country_kaggle/recipes.csv
+++ b/examples/recipes_by_country_kaggle/recipes.csv
@@ -1,0 +1,61 @@
+Name,Ingredients,Cooking Time,Country,Meals
+Seychelles Banana Pancakes,"[""Ripe bananas"",""Flour"",""Milk"",""Eggs"",""Sugar"",""Vanilla extract""]",20,Seychelles ,Breakfast
+Seychelles Coconut French Toast,"[""Bread"",""Coconut milk"",""Eggs"",""Sugar"",""Cinnamon""]",25,Seychelles ,Breakfast
+Seychelles Fish Curry,"[""White Fish Fillets"",""Curry Powder"",""Coconut Milk"",""Onion"",""Garlic"",""Ginger"",""Tomatoes""]",45,Seychelles ,Lunch
+Seychelles Lentil Soup,"[""Red Lentils"",""Vegetable Broth"",""Carrots"",""Celery"",""Onion"",""Garlic"",""Spices""]",35,Seychelles ,Lunch
+Seychelles Grilled Fish with Creole Sauce,"[""Fish Fillets"",""Creole Sauce"",""Lime Juice"",""Garlic"",""Ginger"",""Spices""]",30,Seychelles ,Dinner
+Seychelles Chicken Curry,"[""Chicken Pieces"",""Curry Powder"",""Coconut Milk"",""Onion"",""Garlic"",""Ginger"",""Tomatoes""]",50,Seychelles ,Dinner
+Canadian Pancakes,"[""Flour"",""Eggs"",""Milk"",""Maple Syrup""]",25,Canada ,Breakfast
+Canadian Bacon and Eggs,"[""Bacon"",""Eggs"",""Toast""]",15,Canada ,Breakfast
+Maple Glazed Salmon,"[""Salmon"",""Maple Syrup"",""Soy Sauce"",""Ginger""]",30,Canada ,Lunch
+Poutine,"[""Potatoes"",""Cheese Curds"",""Gravy""]",40,Canada ,Lunch
+Canadian Tourtière,"[""Beef"",""Potatoes"",""Carrots"",""Turnip""]",60,Canada ,Dinner
+Canadian Pea Soup,"[""Pea Soup Mix"",""Ham Hock"",""Vegetables""]",50,Canada ,Dinner
+Argentine Empanadas,"[""Beef"",""Onions"",""Peppers"",""Spices""]",45,Argentina ,Breakfast
+Medialunas,"[""Flour"",""Yeast"",""Butter"",""Sugar""]",30,Argentina ,Breakfast
+Asado Sandwiches,"[""Asado"",""Bread"",""Chimichurri""]",20,Argentina ,Lunch
+Milanesa Sandwich,"[""Milanesa"",""Bread"",""Lettuce"",""Tomato""]",15,Argentina ,Lunch
+Carbonada Criolla,"[""Beef"",""Potatoes"",""Squash"",""Corn""]",60,Argentina ,Dinner
+Locro,"[""White corn"",""Beans"",""Squash"",""Meat""]",120,Argentina ,Dinner
+Beignets,"[""Flour"",""Sugar"",""Yeast"",""Milk"",""Eggs""]",15,Central African Rep. ,Breakfast
+Fried Plantains,"[""Plantains"",""Oil"",""Salt""]",10,Central African Rep. ,Breakfast
+Peanut Stew,"[""Peanut butter"",""Tomatoes"",""Onions"",""Chicken"",""Rice""]",25,Central African Rep. ,Lunch
+Cassava Leaves Stew,"[""Cassava leaves"",""Palm oil"",""Fish"",""Onions""]",30,Central African Rep. ,Lunch
+Grilled Fish,"[""Fish"",""Lemon"",""Garlic"",""Spices""]",45,Central African Rep. ,Dinner
+Beef Stew,"[""Beef"",""Potatoes"",""Carrots"",""Onions"",""Tomatoes""]",60,Central African Rep. ,Dinner
+Afghan Omelet,"[""Eggs"",""Tomatoes"",""Onions"",""Spices""]",25,Afghanistan ,Breakfast
+Afghan Cheese Naan,"[""Naan bread"",""Cheese"",""Grapes""]",20,Afghanistan ,Breakfast
+Kabuli Palaw,"[""Rice"",""Lamb"",""Carrots"",""Raisins""]",60,Afghanistan ,Lunch
+Chicken Tikka Masala,"[""Chicken"",""Tomatoes"",""Onions"",""Spices""]",45,Afghanistan ,Lunch
+Lamb Sabzi,"[""Lamb"",""Spinach"",""Yogurt"",""Spices""]",90,Afghanistan ,Dinner
+Maash Palaw,"[""Rice"",""Beef"",""Lentils"",""Spices""]",75,Afghanistan ,Dinner
+Pepperpot,"[""Beef"",""Cassareep"",""Pepper"",""Spices""]",60,Guyana ,Breakfast
+Bake and Saltfish,"[""Saltfish"",""Flour"",""Baking Powder"",""Oil""]",30,Guyana ,Breakfast
+Cook-up Rice,"[""Rice"",""Coconut Milk"",""Meat"",""Vegetables""]",45,Guyana ,Lunch
+Metemgee,"[""Coconut Milk"",""Dumplings"",""Cassava"",""Plantains"",""Meat""]",50,Guyana ,Lunch
+Chicken Curry,"[""Chicken"",""Curry Powder"",""Potatoes"",""Spices""]",55,Guyana ,Dinner
+Garlic Pork,"[""Pork"",""Garlic"",""Vinegar"",""Spices""]",70,Guyana ,Dinner
+Monaco Breakfast,"[""Eggs"",""Bacon"",""Toast"",""Coffee""]",15,Monaco ,Breakfast
+Croissant Breakfast,"[""Croissant"",""Jam"",""Butter"",""Tea""]",10,Monaco ,Breakfast
+Monaco Salad,"[""Salad"",""Bread"",""Cheese"",""Fruits""]",20,Monaco ,Lunch
+Pasta Lunch,"[""Pasta"",""Tomato Sauce"",""Meatballs"",""Vegetables""]",30,Monaco ,Lunch
+Steak Dinner,"[""Steak"",""Potatoes"",""Asparagus"",""Wine""]",45,Monaco ,Dinner
+Fish Dinner,"[""Fish"",""Rice"",""Vegetables"",""Lemon""]",35,Monaco ,Dinner
+Egg Tart,"[""Eggs"",""Sugar"",""Flour"",""Butter"",""Milk""]",30,Macau ,Breakfast
+Pork Chop Bun,"[""Pork Chop"",""Bun"",""Garlic"",""Soy Sauce""]",20,Macau ,Breakfast
+Almond Cookies,"[""Almond Flour"",""Sugar"",""Egg White"",""Almond Extract""]",25,Macau ,Lunch
+Shrimp Roe Noodles,"[""Noodles"",""Shrimp Roe"",""Soy Sauce"",""Green Onions""]",15,Macau ,Lunch
+African Chicken,"[""Chicken"",""Coconut Milk"",""Peanuts"",""Chili"",""Garlic""]",45,Macau ,Dinner
+Minchi,"[""Ground Meat"",""Molasses"",""Potatoes"",""Onions"",""Soy Sauce""]",35,Macau ,Dinner
+Nasi Lemak,"[""Eggs"",""Toast"",""Butter"",""Jam""]",15,Brunei ,Breakfast
+Kuih Mor,"[""Cereal"",""Milk"",""Fruits""]",5,Brunei ,Breakfast
+Ambuyat,"[""Rice"",""Chicken"",""Vegetables"",""Spices""]",45,Brunei ,Lunch
+Belutak,"[""Noodles"",""Beef"",""Vegetables"",""Soy Sauce""]",30,Brunei ,Lunch
+Udang Sambal Serai,"[""Fish"",""Rice"",""Vegetables"",""Sambal""]",60,Brunei ,Dinner
+Nasi Katok,"[""Chicken"",""Rice"",""Vegetables"",""Sauce""]",40,Brunei ,Dinner
+Rusks,"[""Flour"",""Sugar"",""Butter"",""Eggs"",""Baking Powder""]",15,South Africa ,Breakfast
+Biltong,"[""Beef"",""Vinegar"",""Salt"",""Pepper"",""Coriander""]",20,South Africa ,Breakfast
+Bunny Chow,"[""Bread"",""Curry"",""Potatoes"",""Meat"",""Spices""]",30,South Africa ,Lunch
+Bobotie,"[""Mince"",""Egg"",""Milk"",""Bread"",""Curry Powder""]",45,South Africa ,Lunch
+Potjiekos,"[""Meat"",""Vegetables"",""Potatoes"",""Carrots"",""Onions""]",60,South Africa ,Dinner
+Malva Pudding,"[""Flour"",""Sugar"",""Butter"",""Eggs"",""Apricot Jam""]",50,South Africa ,Dinner

--- a/examples/recipes_by_country_kaggle/recipes.json
+++ b/examples/recipes_by_country_kaggle/recipes.json
@@ -1,0 +1,57 @@
+{
+  "name": "recipes",
+  "description": "A table of recipes with their ingredients, cooking time, and meal types.",
+  "sources": [
+    {
+      "name": "country",
+      "type": "csv",
+      "kaggle": "fernandol/countries-of-the-world",
+      "paths": ["*.csv"]
+    },
+    {
+      "name": "meals",
+      "type": "list",
+      "options": ["Breakfast", "Lunch", "Dinner"]
+    }
+  ],
+  "columns": [
+    {
+      "name": "Name",
+      "description": "The name of the recipe.",
+      "type": "string",
+      "fill_mode": "ai",
+      "context_length": 5
+    },
+    {
+      "name": "Ingredients",
+      "description": "A list of ingredients required for the recipe.",
+      "type": "array",
+      "fill_mode": "ai"
+    },
+    {
+      "name": "Cooking Time",
+      "description": "The time required to cook the recipe in minutes.",
+      "type": "integer",
+      "fill_mode": "ai"
+    },
+    {
+      "name": "Country",
+      "description": "The country of origin of the recipe.",
+      "type": "string",
+      "fill_mode": "pick",
+      "source": "country",
+      "linked_column": "Country",
+      "linked_context_columns": ["Country"],
+      "random": true,
+      "repeat": 6
+    },
+    {
+      "name": "Meals",
+      "description": "The meal type (e.g., Breakfast, Lunch, Dinner) for which the recipe is intended.",
+      "type": "string",
+      "fill_mode": "pick",
+      "source": "meals",
+      "repeat": 2
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.13.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jarcoal/httpmock v1.3.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=

--- a/services/table/rows_generator.go
+++ b/services/table/rows_generator.go
@@ -337,7 +337,7 @@ func (g *AIRowsGenerator) columnSourceIndexer(ctx context.Context, raw json.RawM
 		if err != nil {
 			return nil, err
 		}
-		err = ls.Init(ctx, g.sourceDataDir)
+		err = ls.Init(ctx, g.logger, g.sourceDataDir)
 		if err != nil {
 			return nil, err
 		}

--- a/services/table/source/csv.go
+++ b/services/table/source/csv.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Yiling-J/tablepilot/services/table/source/csvindexer"
 	"github.com/Yiling-J/tablepilot/services/table/source/kaggle"
 	"github.com/bmatcuk/doublestar/v4"
+	"go.uber.org/zap"
 )
 
 type CsvSource struct {
@@ -23,11 +24,11 @@ type CsvSource struct {
 	ContextColumns []string `json:"context_columns"`
 }
 
-func (cs *CsvSource) getRoot(ctx context.Context, dir string) (*os.Root, string, error) {
+func (cs *CsvSource) getRoot(ctx context.Context, logger *zap.SugaredLogger, dir string) (*os.Root, string, error) {
 	var root *os.Root
 	rootPath := dir
 	if cs.Kaggle != "" {
-		rp, err := kaggle.PrepareKaggleDataset(ctx, cs.Kaggle, dir)
+		rp, err := kaggle.PrepareKaggleDataset(ctx, logger, cs.Kaggle, dir)
 		if err != nil {
 			return nil, "", err
 		}
@@ -46,8 +47,8 @@ func (cs *CsvSource) getRoot(ctx context.Context, dir string) (*os.Root, string,
 	return root, rootPath, nil
 }
 
-func (cs *CsvSource) Init(ctx context.Context, dir string) error {
-	root, rootPath, err := cs.getRoot(ctx, dir)
+func (cs *CsvSource) Init(ctx context.Context, logger *zap.SugaredLogger, dir string) error {
+	root, rootPath, err := cs.getRoot(ctx, logger, dir)
 	if err != nil {
 		return err
 	}
@@ -65,8 +66,8 @@ func (cs *CsvSource) Init(ctx context.Context, dir string) error {
 	return nil
 }
 
-func (cs *CsvSource) GetColumns(ctx context.Context, dir string) ([]string, error) {
-	root, rootPath, err := cs.getRoot(ctx, dir)
+func (cs *CsvSource) GetColumns(ctx context.Context, logger *zap.SugaredLogger, dir string) ([]string, error) {
+	root, rootPath, err := cs.getRoot(ctx, logger, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/services/table/source/csv.go
+++ b/services/table/source/csv.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/Yiling-J/tablepilot/ent/schema"
 	"github.com/Yiling-J/tablepilot/services/table/source/csvindexer"
+	"github.com/Yiling-J/tablepilot/services/table/source/kaggle"
 	"github.com/bmatcuk/doublestar/v4"
 )
 
@@ -16,17 +18,41 @@ type CsvSource struct {
 	randomCSV      *csvindexer.CSVIndexer
 	Type           string   `json:"type"`
 	Paths          []string `json:"paths"`
+	Kaggle         string   `json:"kaggle"`
 	Column         string   `json:"column"`
 	ContextColumns []string `json:"context_columns"`
 }
 
+func (cs *CsvSource) getRoot(ctx context.Context, dir string) (*os.Root, string, error) {
+	var root *os.Root
+	rootPath := dir
+	if cs.Kaggle != "" {
+		rp, err := kaggle.PrepareKaggleDataset(ctx, cs.Kaggle, dir)
+		if err != nil {
+			return nil, "", err
+		}
+		root, err = os.OpenRoot(rp)
+		if err != nil {
+			return nil, "", err
+		}
+		rootPath = rp
+	} else {
+		var err error
+		root, err = os.OpenRoot(dir)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	return root, rootPath, nil
+}
+
 func (cs *CsvSource) Init(ctx context.Context, dir string) error {
-	root, err := os.OpenRoot(dir)
+	root, rootPath, err := cs.getRoot(ctx, dir)
 	if err != nil {
 		return err
 	}
 	fileSystem := root.FS()
-	files, err := parsePaths(fileSystem, cs.Paths)
+	files, err := parsePaths(fileSystem, rootPath, cs.Paths)
 	if err != nil {
 		return err
 	}
@@ -35,12 +61,17 @@ func (cs *CsvSource) Init(ctx context.Context, dir string) error {
 		return err
 	}
 	cs.randomCSV = rs
+
 	return nil
 }
 
 func (cs *CsvSource) GetColumns(ctx context.Context, dir string) ([]string, error) {
-	fileSystem := os.DirFS(dir)
-	files, err := parsePaths(fileSystem, cs.Paths)
+	root, rootPath, err := cs.getRoot(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	fileSystem := root.FS()
+	files, err := parsePaths(fileSystem, rootPath, cs.Paths)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +104,7 @@ func (cs *CsvSource) Total() int {
 	return cs.randomCSV.Total()
 }
 
-func parsePaths(fileSystem fs.FS, paths []string) ([]string, error) {
+func parsePaths(fileSystem fs.FS, root string, paths []string) ([]string, error) {
 	fm := map[string]bool{}
 	results := []string{}
 	for _, p := range paths {
@@ -84,7 +115,7 @@ func parsePaths(fileSystem fs.FS, paths []string) ([]string, error) {
 		for _, f := range files {
 			if _, ok := fm[f]; !ok {
 				fm[f] = true
-				results = append(results, f)
+				results = append(results, filepath.Join(root, f))
 			}
 		}
 	}

--- a/services/table/source/csv_test.go
+++ b/services/table/source/csv_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestSource_CSVParsePaths(t *testing.T) {
@@ -94,7 +95,7 @@ func TestSource_CSV(t *testing.T) {
 		require.NoError(t, tmpFile.Close())
 
 		so := &CsvSource{Paths: []string{"test*.csv"}}
-		err = so.Init(ctx, "./")
+		err = so.Init(ctx, zap.NewNop().Sugar(), "./")
 		require.NoError(t, err)
 		indexer := NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{}})
 		v, err := indexer.Next(ctx)
@@ -107,7 +108,7 @@ func TestSource_CSV(t *testing.T) {
 		require.Equal(t, map[string]any{}, v.ContextValue)
 
 		so = &CsvSource{Paths: []string{"test*.csv"}}
-		err = so.Init(ctx, "./")
+		err = so.Init(ctx, zap.NewNop().Sugar(), "./")
 		require.NoError(t, err)
 		indexer = NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{"Name", "Job"}})
 		v, err = indexer.Next(ctx)
@@ -138,7 +139,7 @@ func TestSource_CSV(t *testing.T) {
 		require.NoError(t, tmpFile.Close())
 
 		so := &CsvSource{Paths: []string{"test*.csv"}}
-		err = so.Init(ctx, "./gogo")
+		err = so.Init(ctx, zap.NewNop().Sugar(), "./gogo")
 		require.NoError(t, err)
 		indexer := NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{}})
 		v, err := indexer.Next(ctx)
@@ -169,7 +170,7 @@ func TestSource_GetColumns(t *testing.T) {
 		require.NoError(t, tmpFile.Close())
 
 		so := &CsvSource{Paths: []string{"test*.csv"}}
-		columns, err := so.GetColumns(ctx, "./")
+		columns, err := so.GetColumns(ctx, zap.NewNop().Sugar(), "./")
 		require.NoError(t, err)
 		require.Equal(t, []string{"Name", "Job", "Age"}, columns)
 	})
@@ -192,7 +193,7 @@ func TestSource_GetColumns(t *testing.T) {
 		require.NoError(t, tmpFile.Close())
 
 		so := &CsvSource{Paths: []string{"test*.csv"}}
-		columns, err := so.GetColumns(ctx, "./gogo")
+		columns, err := so.GetColumns(ctx, zap.NewNop().Sugar(), "./gogo")
 		require.NoError(t, err)
 		require.Equal(t, []string{"Name", "Job", "Age"}, columns)
 	})
@@ -228,7 +229,7 @@ func TestSource_KaggleCSV(t *testing.T) {
 		httpmock.NewBytesResponder(200, mockZip).Once())
 
 	so := &CsvSource{Paths: []string{"foo_*.csv"}, Kaggle: "foo/bar"}
-	err := so.Init(ctx, "./")
+	err := so.Init(ctx, zap.NewNop().Sugar(), "./")
 	defer func() { _ = os.RemoveAll("tablepilot_kaggle_cache/foo--bar") }()
 	require.NoError(t, err)
 	indexer := NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{}})
@@ -248,7 +249,7 @@ func TestSource_KaggleGetColumns(t *testing.T) {
 		httpmock.NewBytesResponder(200, mockZip).Once())
 
 	so := &CsvSource{Paths: []string{"foo_*.csv"}, Kaggle: "foo/bar"}
-	columns, err := so.GetColumns(ctx, "./")
+	columns, err := so.GetColumns(ctx, zap.NewNop().Sugar(), "./")
 	defer func() { _ = os.RemoveAll("tablepilot_kaggle_cache/foo--bar") }()
 	require.NoError(t, err)
 	require.Equal(t, []string{"Name", "Age"}, columns)

--- a/services/table/source/csv_test.go
+++ b/services/table/source/csv_test.go
@@ -1,6 +1,8 @@
 package source
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/csv"
 	"os"
@@ -8,6 +10,7 @@ import (
 	"testing/fstest"
 
 	"github.com/Yiling-J/tablepilot/ent"
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,7 +66,7 @@ func TestSource_CSVParsePaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := parsePaths(mockFS, tt.paths)
+			result, err := parsePaths(mockFS, "./", tt.paths)
 			if tt.err {
 				assert.Error(t, err)
 			} else {
@@ -75,43 +78,178 @@ func TestSource_CSVParsePaths(t *testing.T) {
 }
 
 func TestSource_CSV(t *testing.T) {
-	ctx := context.TODO()
+	t.Run("default root", func(t *testing.T) {
+		ctx := context.TODO()
 
-	tmpFile, err := os.CreateTemp("./", "test_*.csv")
+		tmpFile, err := os.CreateTemp("./", "test_*.csv")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		writer := csv.NewWriter(tmpFile)
+		require.NoError(t, writer.Write([]string{"Name", "Job", "Age"}))
+		require.NoError(t, writer.Write([]string{"me", "Engineer", "1"}))
+		require.NoError(t, writer.Write([]string{"you", "Doctor", "2"}))
+		writer.Flush()
+		require.NoError(t, writer.Error())
+		require.NoError(t, tmpFile.Close())
+
+		so := &CsvSource{Paths: []string{"test*.csv"}}
+		err = so.Init(ctx, "./")
+		require.NoError(t, err)
+		indexer := NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{}})
+		v, err := indexer.Next(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "me", v.Value)
+		require.Equal(t, map[string]any{}, v.ContextValue)
+		v, err = indexer.Next(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "you", v.Value)
+		require.Equal(t, map[string]any{}, v.ContextValue)
+
+		so = &CsvSource{Paths: []string{"test*.csv"}}
+		err = so.Init(ctx, "./")
+		require.NoError(t, err)
+		indexer = NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{"Name", "Job"}})
+		v, err = indexer.Next(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "me", v.Value)
+		require.Equal(t, map[string]any{"Name": "me", "Job": "Engineer"}, v.ContextValue)
+		v, err = indexer.Next(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "you", v.Value)
+		require.Equal(t, map[string]any{"Name": "you", "Job": "Doctor"}, v.ContextValue)
+	})
+
+	t.Run("different root", func(t *testing.T) {
+		ctx := context.TODO()
+
+		err := os.Mkdir("./gogo", os.ModePerm)
+		require.NoError(t, err)
+		tmpFile, err := os.CreateTemp("./gogo", "test_*.csv")
+		require.NoError(t, err)
+		defer os.RemoveAll("./gogo")
+
+		writer := csv.NewWriter(tmpFile)
+		require.NoError(t, writer.Write([]string{"Name", "Job", "Age"}))
+		require.NoError(t, writer.Write([]string{"me", "Engineer", "1"}))
+		require.NoError(t, writer.Write([]string{"you", "Doctor", "2"}))
+		writer.Flush()
+		require.NoError(t, writer.Error())
+		require.NoError(t, tmpFile.Close())
+
+		so := &CsvSource{Paths: []string{"test*.csv"}}
+		err = so.Init(ctx, "./gogo")
+		require.NoError(t, err)
+		indexer := NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{}})
+		v, err := indexer.Next(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "me", v.Value)
+		require.Equal(t, map[string]any{}, v.ContextValue)
+		v, err = indexer.Next(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "you", v.Value)
+		require.Equal(t, map[string]any{}, v.ContextValue)
+	})
+}
+
+func TestSource_GetColumns(t *testing.T) {
+	t.Run("default root", func(t *testing.T) {
+		ctx := context.TODO()
+
+		tmpFile, err := os.CreateTemp("./", "test_*.csv")
+		require.NoError(t, err)
+		defer os.Remove(tmpFile.Name())
+
+		writer := csv.NewWriter(tmpFile)
+		require.NoError(t, writer.Write([]string{"Name", "Job", "Age"}))
+		require.NoError(t, writer.Write([]string{"me", "Engineer", "1"}))
+		require.NoError(t, writer.Write([]string{"you", "Doctor", "2"}))
+		writer.Flush()
+		require.NoError(t, writer.Error())
+		require.NoError(t, tmpFile.Close())
+
+		so := &CsvSource{Paths: []string{"test*.csv"}}
+		columns, err := so.GetColumns(ctx, "./")
+		require.NoError(t, err)
+		require.Equal(t, []string{"Name", "Job", "Age"}, columns)
+	})
+
+	t.Run("different root", func(t *testing.T) {
+		ctx := context.TODO()
+
+		err := os.Mkdir("./gogo", os.ModePerm)
+		require.NoError(t, err)
+		tmpFile, err := os.CreateTemp("./gogo", "test_*.csv")
+		require.NoError(t, err)
+		defer os.RemoveAll("./gogo")
+
+		writer := csv.NewWriter(tmpFile)
+		require.NoError(t, writer.Write([]string{"Name", "Job", "Age"}))
+		require.NoError(t, writer.Write([]string{"me", "Engineer", "1"}))
+		require.NoError(t, writer.Write([]string{"you", "Doctor", "2"}))
+		writer.Flush()
+		require.NoError(t, writer.Error())
+		require.NoError(t, tmpFile.Close())
+
+		so := &CsvSource{Paths: []string{"test*.csv"}}
+		columns, err := so.GetColumns(ctx, "./gogo")
+		require.NoError(t, err)
+		require.Equal(t, []string{"Name", "Job", "Age"}, columns)
+	})
+}
+
+func createTestZipCSV(t *testing.T) []byte {
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+	defer zipWriter.Close()
+
+	csvFile, err := zipWriter.Create("foo_bar.csv")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
 
-	writer := csv.NewWriter(tmpFile)
-	require.NoError(t, writer.Write([]string{"Name", "Job", "Age"}))
-	require.NoError(t, writer.Write([]string{"me", "Engineer", "1"}))
-	require.NoError(t, writer.Write([]string{"you", "Doctor", "2"}))
+	writer := csv.NewWriter(csvFile)
+	err = writer.Write([]string{"Name", "Age"})
+	require.NoError(t, err)
+	err = writer.Write([]string{"Alice", "30"})
+	require.NoError(t, err)
 	writer.Flush()
-	require.NoError(t, writer.Error())
-	require.NoError(t, tmpFile.Close())
 
-	so := &CsvSource{Paths: []string{"test*.csv"}}
-	err = so.Init(ctx, "./")
+	err = zipWriter.Close()
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+func TestSource_KaggleCSV(t *testing.T) {
+	ctx := context.TODO()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mockZip := createTestZipCSV(t)
+	httpmock.RegisterResponder("GET", "https://www.kaggle.com/api/v1/datasets/download/foo/bar",
+		httpmock.NewBytesResponder(200, mockZip).Once())
+
+	so := &CsvSource{Paths: []string{"foo_*.csv"}, Kaggle: "foo/bar"}
+	err := so.Init(ctx, "./")
+	defer func() { _ = os.RemoveAll("tablepilot_kaggle_cache/foo--bar") }()
 	require.NoError(t, err)
 	indexer := NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{}})
 	v, err := indexer.Next(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "me", v.Value)
+	require.Equal(t, "Alice", v.Value)
 	require.Equal(t, map[string]any{}, v.ContextValue)
-	v, err = indexer.Next(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "you", v.Value)
-	require.Equal(t, map[string]any{}, v.ContextValue)
+}
 
-	so = &CsvSource{Paths: []string{"test*.csv"}}
-	err = so.Init(ctx, "./")
+func TestSource_KaggleGetColumns(t *testing.T) {
+	ctx := context.TODO()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mockZip := createTestZipCSV(t)
+	httpmock.RegisterResponder("GET", "https://www.kaggle.com/api/v1/datasets/download/foo/bar",
+		httpmock.NewBytesResponder(200, mockZip).Once())
+
+	so := &CsvSource{Paths: []string{"foo_*.csv"}, Kaggle: "foo/bar"}
+	columns, err := so.GetColumns(ctx, "./")
+	defer func() { _ = os.RemoveAll("tablepilot_kaggle_cache/foo--bar") }()
 	require.NoError(t, err)
-	indexer = NewIndexer(so, &ent.TableColumn{Random: false, LinkedColumn: "Name", LinkedContextColumns: []string{"Name", "Job"}})
-	v, err = indexer.Next(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "me", v.Value)
-	require.Equal(t, map[string]any{"Name": "me", "Job": "Engineer"}, v.ContextValue)
-	v, err = indexer.Next(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "you", v.Value)
-	require.Equal(t, map[string]any{"Name": "you", "Job": "Doctor"}, v.ContextValue)
+	require.Equal(t, []string{"Name", "Age"}, columns)
 }

--- a/services/table/source/kaggle/kaggle.go
+++ b/services/table/source/kaggle/kaggle.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 func download(dir string, url string) error {
@@ -94,22 +96,25 @@ func unzip(src string, dest string) error {
 }
 
 // PrepareKaggleDataset download zip file using kaggle API and unzip to tablepilot_kaggle_cache folder
-func PrepareKaggleDataset(ctx context.Context, dataset string, dir string) (string, error) {
+func PrepareKaggleDataset(ctx context.Context, logger *zap.SugaredLogger, dataset string, dir string) (string, error) {
 	path := strings.ReplaceAll(dataset, "/", "--")
 	cachePath := filepath.Join(dir, "tablepilot_kaggle_cache", path)
 	zipPath := filepath.Join(dir, "tablepilot_kaggle_cache/tmp", path)
 	_, err := os.Stat(cachePath)
 	// cache exists
 	if err == nil {
+		logger.Debug("find cached kaggle dataset", "path", cachePath)
 		return "", nil
 	}
 
 	// download kaggle dataset zip
 	url := fmt.Sprintf("https://www.kaggle.com/api/v1/datasets/download/%s", dataset)
+	logger.Debug("start downloading kaggle dataset", "dataset", dataset)
 	err = download(zipPath, url)
 	defer func() { _ = os.RemoveAll(zipPath) }()
 	if err != nil {
 		return "", err
 	}
+	logger.Debug("finish downloading kaggle dataset", "dataset", dataset)
 	return cachePath, unzip(filepath.Join(zipPath, "download.zip"), cachePath)
 }

--- a/services/table/source/kaggle/kaggle.go
+++ b/services/table/source/kaggle/kaggle.go
@@ -1,0 +1,115 @@
+package kaggle
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func download(dir string, url string) error {
+	resp, err := http.Get(url) //nolint
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	err = os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	out, err := os.Create(filepath.Join(dir, "download.zip"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+// https://snyk.io/research/zip-slip-vulnerability
+// https://github.com/securego/gosec/issues/324#issuecomment-935927967
+func sanitizeArchivePath(dest string, filename string) (v string, err error) {
+	v = filepath.Join(dest, filename)
+	if strings.HasPrefix(v, filepath.Clean(dest)) {
+		return v, nil
+	}
+
+	return "", fmt.Errorf("%s: %s", "content filepath is tainted", filename)
+}
+
+func unzip(src string, dest string) error {
+	zipReader, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer zipReader.Close()
+
+	for _, file := range zipReader.File {
+		filePath, err := sanitizeArchivePath(dest, file.Name)
+		if err != nil {
+			return err
+		}
+
+		if file.FileInfo().IsDir() {
+			err = os.MkdirAll(filePath, os.ModePerm)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		err = os.MkdirAll(filepath.Dir(filePath), os.ModePerm)
+		if err != nil {
+			return err
+		}
+
+		outFile, err := os.Create(filePath)
+		if err != nil {
+			return err
+		}
+		defer outFile.Close()
+
+		zipFile, err := file.Open()
+		if err != nil {
+			return err
+		}
+		defer zipFile.Close()
+		for {
+			_, err := io.CopyN(outFile, zipFile, 2<<20)
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// PrepareKaggleDataset download zip file using kaggle API and unzip to tablepilot_kaggle_cache folder
+func PrepareKaggleDataset(ctx context.Context, dataset string, dir string) (string, error) {
+	path := strings.ReplaceAll(dataset, "/", "--")
+	cachePath := filepath.Join(dir, "tablepilot_kaggle_cache", path)
+	zipPath := filepath.Join(dir, "tablepilot_kaggle_cache/tmp", path)
+	_, err := os.Stat(cachePath)
+	// cache exists
+	if err == nil {
+		return "", nil
+	}
+
+	// download kaggle dataset zip
+	url := fmt.Sprintf("https://www.kaggle.com/api/v1/datasets/download/%s", dataset)
+	err = download(zipPath, url)
+	defer func() { _ = os.RemoveAll(zipPath) }()
+	if err != nil {
+		return "", err
+	}
+	return cachePath, unzip(filepath.Join(zipPath, "download.zip"), cachePath)
+}

--- a/services/table/source/kaggle/kaggle.go
+++ b/services/table/source/kaggle/kaggle.go
@@ -104,7 +104,7 @@ func PrepareKaggleDataset(ctx context.Context, logger *zap.SugaredLogger, datase
 	// cache exists
 	if err == nil {
 		logger.Debug("find cached kaggle dataset", "path", cachePath)
-		return "", nil
+		return cachePath, nil
 	}
 
 	// download kaggle dataset zip

--- a/services/table/source/kaggle/kaggle_test.go
+++ b/services/table/source/kaggle/kaggle_test.go
@@ -1,0 +1,71 @@
+package kaggle
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestZipCSV(t *testing.T) []byte {
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+	defer zipWriter.Close()
+
+	csvFile, err := zipWriter.Create("test.csv")
+	require.NoError(t, err)
+
+	writer := csv.NewWriter(csvFile)
+	err = writer.Write([]string{"Name", "Age"})
+	require.NoError(t, err)
+	err = writer.Write([]string{"Alice", "30"})
+	require.NoError(t, err)
+	writer.Flush()
+
+	err = zipWriter.Close()
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+func TestKaggle_PrepareKaggleDataset(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mockZip := createTestZipCSV(t)
+	httpmock.RegisterResponder("GET", "https://www.kaggle.com/api/v1/datasets/download/jessicali9530/lfw-dataset",
+		httpmock.NewBytesResponder(200, mockZip).Once())
+
+	path, err := PrepareKaggleDataset(context.TODO(), "jessicali9530/lfw-dataset", "./")
+	defer func() { _ = os.RemoveAll("tablepilot_kaggle_cache/jessicali9530--lfw-dataset") }()
+	require.NoError(t, err)
+	require.Equal(t, "tablepilot_kaggle_cache/jessicali9530--lfw-dataset", path)
+	info, err := os.Stat("tablepilot_kaggle_cache/jessicali9530--lfw-dataset")
+	require.NoError(t, err)
+	require.Equal(t, true, info.IsDir())
+	files, err := os.ReadDir("tablepilot_kaggle_cache/jessicali9530--lfw-dataset")
+	require.NoError(t, err)
+	var found bool
+	for _, f := range files {
+		if f.Name() == "test.csv" {
+			found = true
+			f, err := os.Open(filepath.Join(path, f.Name()))
+			defer func() { _ = f.Close() }()
+			require.NoError(t, err)
+			csvReader := csv.NewReader(f)
+			records, err := csvReader.ReadAll()
+			require.NoError(t, err)
+			require.Equal(t, [][]string{{"Name", "Age"}, {"Alice", "30"}}, records)
+		}
+	}
+	require.True(t, found)
+
+	// prepare again, not http request this time because files are cached
+	_, err = PrepareKaggleDataset(context.TODO(), "jessicali9530/lfw-dataset", "./")
+	require.NoError(t, err)
+}

--- a/services/table/source/kaggle/kaggle_test.go
+++ b/services/table/source/kaggle/kaggle_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func createTestZipCSV(t *testing.T) []byte {
@@ -41,7 +42,7 @@ func TestKaggle_PrepareKaggleDataset(t *testing.T) {
 	httpmock.RegisterResponder("GET", "https://www.kaggle.com/api/v1/datasets/download/jessicali9530/lfw-dataset",
 		httpmock.NewBytesResponder(200, mockZip).Once())
 
-	path, err := PrepareKaggleDataset(context.TODO(), "jessicali9530/lfw-dataset", "./")
+	path, err := PrepareKaggleDataset(context.TODO(), zap.NewNop().Sugar(), "jessicali9530/lfw-dataset", "./")
 	defer func() { _ = os.RemoveAll("tablepilot_kaggle_cache/jessicali9530--lfw-dataset") }()
 	require.NoError(t, err)
 	require.Equal(t, "tablepilot_kaggle_cache/jessicali9530--lfw-dataset", path)
@@ -66,6 +67,6 @@ func TestKaggle_PrepareKaggleDataset(t *testing.T) {
 	require.True(t, found)
 
 	// prepare again, not http request this time because files are cached
-	_, err = PrepareKaggleDataset(context.TODO(), "jessicali9530/lfw-dataset", "./")
+	_, err = PrepareKaggleDataset(context.TODO(), zap.NewNop().Sugar(), "jessicali9530/lfw-dataset", "./")
 	require.NoError(t, err)
 }

--- a/services/table/source/kaggle/kaggle_test.go
+++ b/services/table/source/kaggle/kaggle_test.go
@@ -67,6 +67,7 @@ func TestKaggle_PrepareKaggleDataset(t *testing.T) {
 	require.True(t, found)
 
 	// prepare again, not http request this time because files are cached
-	_, err = PrepareKaggleDataset(context.TODO(), zap.NewNop().Sugar(), "jessicali9530/lfw-dataset", "./")
+	path, err = PrepareKaggleDataset(context.TODO(), zap.NewNop().Sugar(), "jessicali9530/lfw-dataset", "./")
 	require.NoError(t, err)
+	require.Equal(t, "tablepilot_kaggle_cache/jessicali9530--lfw-dataset", path)
 }

--- a/services/table/table.go
+++ b/services/table/table.go
@@ -82,7 +82,7 @@ func NewTableService(config *config.Config, db *ent.Client, ai ai.AiService, log
 			ss := &SharedSource{Name: name}
 			switch st := so.(type) {
 			case *source.CsvSource:
-				columns, err := st.GetColumns(context.Background(), config.Common.SourceDataDir)
+				columns, err := st.GetColumns(context.Background(), ts.logger, config.Common.SourceDataDir)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
  - **kaggle**: The Kaggle dataset name, e.g., `"fernandol/countries-of-the-world"`.

    You can use a Kaggle dataset as a CSV data source. When doing so, Tablepilot first downloads the dataset into a cache folder:

    ```
    {source_data_dir}/tablepilot_kaggle_cache/{dataset_name (with `/` replaced by `--`)}
    ```

    Once downloaded, it functions like a local CSV source. The only difference is that the search root for `paths` is relative to the downloaded folder. The cached dataset will always be used unless you remove it manually.

    **Example:**
    ```json
    {
      "name": "countries",
      "type": "csv",
      "kaggle": "fernandol/countries-of-the-world",
      "paths": ["*.csv"]
    }
    ```

    You can find the dataset name by clicking the **Download** button in the top-right corner of the dataset page on Kaggle.