### PR TITLE
Update table command

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,13 +18,37 @@ POST /tables
 ```
 #### Request Body
 
-See [examples directory](https://github.com/Yiling-J/tablepilot/tree/main/examples) for more examples.
+The JSON body of this API follows the same syntax as the CLI schema file. See [examples directory](https://github.com/Yiling-J/tablepilot/tree/main/examples) for more examples.
 
 ```json
 {
   "name": "recipes",
   "model": "m1",
   "description": "all recipes",
+  "columns": [
+    {"name": "recipe_name", "description": "Name of the recipe", "type": "string", "fill_mode": "ai"}
+  ],
+  "sources": [
+    {"name": "cuisines"}
+  ]
+}
+```
+#### Response
+```json
+{
+  "id": "foo"
+}
+```
+
+### Update a Table
+#### Endpoint
+```
+PATCH /tables/{table_id or table_name}
+```
+#### Request Body
+
+```json
+{
   "columns": [
     {"name": "recipe_name", "description": "Name of the recipe", "type": "string", "fill_mode": "ai"}
   ],

--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ A number of examples demonstrating various use cases of Tablepilot are available
   ```
   **Important**: If you modify the JSON schema after creating a table, be sure to delete the existing table then recreating it.
 
+- **update**
+  Update table from schema JSON file.
+  ```
+  tablepilot update recipes.json -t=recipes
+  ```
+  - `-t, --table string`
+	 Table ID or name to update. If not provided, the name field in the JSON file will be used.
+
+  The update command compares the existing columns in the database with those in the JSON file and matches them by column name. Columns present in both the database and JSON file will be updated. Columns missing from the JSON file will be removed. And if the table already contains data: Removed columns will also have their data deleted, newly added columns will be initialized with their zero value.
+
 - **delete**
   Delete a specified table.
   ```

--- a/api/api.go
+++ b/api/api.go
@@ -22,7 +22,7 @@ func (hs *HTTPServer) CreateTable(ctx *gin.Context) {
 	}
 	request.MarkAPIRequest()
 
-	uid, err := hs.TableService.CreateTable(ctx.Request.Context(), &request)
+	uid, err := hs.TableService.Create(ctx.Request.Context(), &request)
 	if err != nil {
 		errorResponse(ctx, 500, err)
 		return

--- a/api/api.go
+++ b/api/api.go
@@ -31,6 +31,24 @@ func (hs *HTTPServer) CreateTable(ctx *gin.Context) {
 	ctx.JSON(200, gin.H{"id": uid})
 }
 
+func (hs *HTTPServer) UpdateTable(ctx *gin.Context) {
+	var request table.TableGenRequest
+	err := ctx.ShouldBindJSON(&request)
+	if err != nil {
+		errorResponse(ctx, 400, err)
+		return
+	}
+	request.MarkAPIRequest()
+
+	uid, err := hs.TableService.Update(ctx.Request.Context(), ctx.Param("table"), &request)
+	if err != nil {
+		errorResponse(ctx, 500, err)
+		return
+	}
+
+	ctx.JSON(200, gin.H{"id": uid})
+}
+
 func sseHeaders(c *gin.Context) {
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache")
@@ -193,6 +211,7 @@ func (hs *HTTPServer) addRouters() {
 	hs.apiv1.POST("/tables", hs.CreateTable)
 	hs.apiv1.GET("/tables", hs.ListTables)
 	hs.apiv1.GET("/tables/:table", hs.Describe)
+	hs.apiv1.PATCH("/tables/:table", hs.UpdateTable)
 	hs.apiv1.POST("/tables/:table", hs.CreateRows)
 	hs.apiv1.DELETE("/tables/:table", hs.Delete)
 	hs.apiv1.POST("/tables/:table/truncate", hs.Truncate)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -41,6 +41,33 @@ func TestAPI_CreateTable(t *testing.T) {
 	resp.ResponseEq(t, 200, map[string]string{"id": "foo"})
 }
 
+func TestAPI_UpdateTable(t *testing.T) {
+	expectedRequest := &table.TableGenRequest{
+		Name:        "recipes",
+		Model:       "m1",
+		Description: "all recipes",
+		Columns: []table.TableGenColumn{
+			{Name: "col1", Description: "desc", Type: "string", FillMode: "ai"},
+		},
+		Sources: []json.RawMessage{[]byte(`{"source":"s"}`)},
+	}
+	expectedRequest.MarkAPIRequest()
+	tableMock := &table.TableServiceMock{
+		UpdateFunc: func(ctx context.Context, tb string, req *table.TableGenRequest) (string, error) {
+			require.Equal(t, "foo", tb)
+			require.Equal(t, expectedRequest, req)
+			return "foo", nil
+		},
+	}
+	server := NewTestServer(t, func(s *services.Backend) {
+		s.TableService = tableMock
+	})
+	req, err := server.NewPatchRequest("/api/v1/tables/foo", expectedRequest)
+	require.NoError(t, err)
+	resp := server.Send(req)
+	resp.ResponseEq(t, 200, map[string]string{"id": "foo"})
+}
+
 func TestAPI_Generate(t *testing.T) {
 	var counter int
 	mockRowGen := &table.RowsGeneratorMock{

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -27,7 +27,7 @@ func TestAPI_CreateTable(t *testing.T) {
 	}
 	expectedRequest.MarkAPIRequest()
 	tableMock := &table.TableServiceMock{
-		CreateTableFunc: func(ctx context.Context, req *table.TableGenRequest) (string, error) {
+		CreateFunc: func(ctx context.Context, req *table.TableGenRequest) (string, error) {
 			require.Equal(t, expectedRequest, req)
 			return "foo", nil
 		},

--- a/api/common_test.go
+++ b/api/common_test.go
@@ -67,6 +67,14 @@ func (ts *TestServer) NewPostRequest(url string, body any) (*http.Request, error
 	return http.NewRequest(http.MethodPost, url, strings.NewReader(string(d)))
 }
 
+func (ts *TestServer) NewPatchRequest(url string, body any) (*http.Request, error) {
+	d, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return http.NewRequest(http.MethodPatch, url, strings.NewReader(string(d)))
+}
+
 func (ts *TestServer) NewPutRequest(url string, body any) (*http.Request, error) {
 	d, err := json.Marshal(body)
 	if err != nil {

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -73,7 +73,7 @@ func BuildCLI(root *cobra.Command) *CLI {
 		Short: "Update an existing table using a schema JSON file",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return handler.Create(cmd, args)
+			return handler.Update(cmd, args)
 		},
 	}
 	updateCommand.Flags().StringP("table", "t", "", "table ID or name to update; defaults to the name field in the JSON if not specified")

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -68,6 +68,17 @@ func BuildCLI(root *cobra.Command) *CLI {
 		},
 	})
 
+	updateCommand := &cobra.Command{
+		Use:   "update <file>...",
+		Short: "Update an existing table using a schema JSON file",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return handler.Create(cmd, args)
+		},
+	}
+	updateCommand.Flags().StringP("table", "t", "", "table ID or name to update; defaults to the name field in the JSON if not specified")
+	cmd.AddCommand(updateCommand)
+
 	cmd.AddCommand(&cobra.Command{
 		Use:   "list",
 		Short: "List all available tables",

--- a/cmd/cli/handler.go
+++ b/cmd/cli/handler.go
@@ -40,7 +40,7 @@ func (h *Handler) Create(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		id, err := h.backend.TableService.CreateTable(cmd.Context(), &req)
+		id, err := h.backend.TableService.Create(cmd.Context(), &req)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/handler.go
+++ b/cmd/cli/handler.go
@@ -49,6 +49,29 @@ func (h *Handler) Create(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func (h *Handler) Update(cmd *cobra.Command, args []string) error {
+	fileName := args[0]
+	tb, err := cmd.Flags().GetString("table")
+	if err != nil {
+		return err
+	}
+	var req table.TableGenRequest
+	f, err := os.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(f, &req)
+	if err != nil {
+		return err
+	}
+	id, err := h.backend.TableService.Update(cmd.Context(), tb, &req)
+	if err != nil {
+		return err
+	}
+	h.backend.Logger.Infow("table updated", "id", id)
+	return nil
+}
+
 func (h *Handler) Show(cmd *cobra.Command, args []string) error {
 	table := args[0]
 	rows, err := h.backend.TableService.Rows(cmd.Context(), table)

--- a/cmd/cli/handler_test.go
+++ b/cmd/cli/handler_test.go
@@ -57,6 +57,44 @@ func TestHandler_Create(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHandler_Update(t *testing.T) {
+	tableMock := &table.TableServiceMock{
+		UpdateFunc: func(ctx context.Context, tb string, req *table.TableGenRequest) (string, error) {
+			require.Equal(t, "foo", tb)
+			require.Equal(t, &table.TableGenRequest{
+				Name: "go",
+				Columns: []table.TableGenColumn{
+					{Name: "c1", Type: "string", FillMode: "ai"},
+				},
+			}, req)
+			return "123", nil
+		},
+	}
+	handler := &Handler{
+		backend: services.NewBackend(
+			&config.Config{}, nil, zap.NewNop().Sugar(),
+			nil, tableMock,
+		),
+	}
+	cmd := &cobra.Command{}
+	cmd.Flags().String("table", "", "")
+	err := cmd.Flags().Set("table", "foo")
+	require.NoError(t, err)
+	testFile := fmt.Sprintf("foo_%d.json", time.Now().UnixNano())
+	file, err := os.Create(testFile)
+	require.NoError(t, err)
+	defer os.Remove(testFile)
+	_, err = file.WriteString(
+		`{"name":"go","columns":[{"name":"c1","type":"string","fill_mode":"ai"}]}`,
+	)
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+	err = handler.Update(cmd, []string{testFile})
+	require.NoError(t, err)
+	require.NoError(t, err)
+}
+
 func TestHandler_Show(t *testing.T) {
 	tableMock := &table.TableServiceMock{
 		RowsFunc: func(ctx context.Context, name string) (*table.Rows, error) {

--- a/cmd/cli/handler_test.go
+++ b/cmd/cli/handler_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestHandler_Create(t *testing.T) {
 	tableMock := &table.TableServiceMock{
-		CreateTableFunc: func(ctx context.Context, req *table.TableGenRequest) (string, error) {
+		CreateFunc: func(ctx context.Context, req *table.TableGenRequest) (string, error) {
 			require.Equal(t, &table.TableGenRequest{
 				Name: "go",
 				Columns: []table.TableGenColumn{

--- a/services/table/table.go
+++ b/services/table/table.go
@@ -262,6 +262,9 @@ func (t *TableServiceImpl) Update(ctx context.Context, table string, req *TableG
 	if req.Name == "" {
 		return "", ent.Rollback(tx, errors.New("table name is empty"))
 	}
+	if table == "" {
+		table = req.Name
+	}
 	sources := map[string]json.RawMessage{}
 	if len(req.Sources) > 0 {
 		for _, raw := range req.Sources {

--- a/services/table/table.go
+++ b/services/table/table.go
@@ -41,7 +41,8 @@ var reflector = jsonschema.Reflector{
 
 //go:generate moq -rm -out table_moq.go . TableService RowsGenerator
 type TableService interface {
-	CreateTable(ctx context.Context, req *TableGenRequest) (string, error)
+	Create(ctx context.Context, req *TableGenRequest) (string, error)
+	Update(ctx context.Context, table string, req *TableGenRequest) (string, error)
 	ListTables(ctx context.Context) (*ListTablesResponse, error)
 	GetTableDetail(ctx context.Context, table string) (*TableInfo, error)
 	Genetate(ctx context.Context, params GenerateRowsRequest) (RowsGenerator, error)
@@ -102,7 +103,7 @@ type TableGenColumnSchema struct {
 	Type        string `json:"type"`
 }
 
-func (t *TableServiceImpl) CreateTable(ctx context.Context, req *TableGenRequest) (string, error) {
+func (t *TableServiceImpl) Create(ctx context.Context, req *TableGenRequest) (string, error) {
 	t.logger.Debugw("creating table", "name", req.Name)
 	tx, err := t.db.Tx(ctx)
 	if err != nil {
@@ -250,6 +251,178 @@ func (t *TableServiceImpl) CreateTable(ctx context.Context, req *TableGenRequest
 
 	t.logger.Debug("finish creating table")
 	return table.Nanoid, tx.Commit()
+}
+
+func (t *TableServiceImpl) Update(ctx context.Context, table string, req *TableGenRequest) (string, error) {
+	t.logger.Debugw("updating table", "table", table)
+	tx, err := t.db.Tx(ctx)
+	if err != nil {
+		return "", fmt.Errorf("starting a transaction: %w", err)
+	}
+	if req.Name == "" {
+		return "", ent.Rollback(tx, errors.New("table name is empty"))
+	}
+	sources := map[string]json.RawMessage{}
+	if len(req.Sources) > 0 {
+		for _, raw := range req.Sources {
+			vs, err := source.ValidateSource(ctx, raw, tx.Client())
+			if err != nil {
+				return "", ent.Rollback(tx, err)
+			}
+			if req.APIRequest() {
+				switch st := vs.(type) {
+				case *source.CsvSource:
+					if len(st.Paths) > 0 {
+						return "", errors.New("paths field for csv source is only allowed in CLI")
+					}
+				case *source.ListSource:
+					if st.File != "" {
+						return "", errors.New("file field for list source is only allowed in CLI")
+					}
+				}
+			}
+			bs, err := json.Marshal(vs)
+			if err != nil {
+				return "", ent.Rollback(tx, err)
+			}
+			sources[gjson.GetBytes(raw, "name").String()] = bs
+		}
+	}
+	if len(t.sharedSources) > 0 {
+		for _, so := range t.sharedSources {
+			if _, ok := sources[so.Name]; !ok {
+				vs, err := source.ValidateSource(ctx, so.Data, tx.Client())
+				if err != nil {
+					return "", ent.Rollback(tx, err)
+				}
+				bs, err := json.Marshal(vs)
+				if err != nil {
+					return "", ent.Rollback(tx, err)
+				}
+				sources[so.Name] = bs
+			}
+		}
+	}
+
+	dbtable, err := tx.TableMeta.Query().Where(tablemeta.Or(
+		tablemeta.Nanoid(table),
+		tablemeta.Name(table),
+	)).WithColumns().Only(ctx)
+	if err != nil {
+		return "", ent.Rollback(tx, err)
+	}
+
+	err = dbtable.Update().SetName(req.Name).SetDescription(req.Description).SetModel(req.Model).SetSources(sources).Exec(ctx)
+	if err != nil {
+		return "", ent.Rollback(tx, err)
+	}
+
+	// validate linked column column/context_columns exists
+	err = validateLinkedColumnInfo(ctx, tx, req.Columns, sources)
+	if err != nil {
+		return "", ent.Rollback(tx, err)
+	}
+
+	reqColumns := map[string]TableGenColumn{}
+	for _, col := range req.Columns {
+		reqColumns[col.Name] = col
+	}
+
+	removed := map[int]bool{}
+	upserts := []TableGenColumn{}
+	exists := map[string]string{}
+	for i, col := range dbtable.Edges.Columns {
+		if v, ok := reqColumns[col.Name]; !ok {
+			removed[i] = true
+			err = tx.TableColumn.DeleteOneID(col.ID).Exec(ctx)
+			if err != nil {
+				return "", ent.Rollback(tx, err)
+			}
+		} else {
+			upserts = append(upserts, v)
+			exists[col.Name] = col.Nanoid
+		}
+	}
+
+	// append new columns and prepare zero values for existing rows
+	zeros := []any{}
+	for _, col := range req.Columns {
+		if col.Name == "" {
+			continue
+		}
+		if _, ok := exists[col.Name]; ok {
+			continue
+		}
+		upserts = append(upserts, col)
+		zv, err := util.ZeroValue(tablecolumn.Type(col.Type))
+		if err != nil {
+			return "", ent.Rollback(tx, err)
+		}
+		zeros = append(zeros, zv)
+	}
+
+	columnCreates := []*ent.TableColumnCreate{}
+	for _, col := range upserts {
+		cr := tx.TableColumn.Create()
+		if nid, ok := exists[col.Name]; ok {
+			cr.SetNanoid(nid)
+		}
+		cc := cr.SetTablemeta(dbtable).
+			SetFillMode(tablecolumn.FillMode(col.FillMode)).
+			SetName(col.Name).
+			SetDescription(col.Description).
+			SetType(tablecolumn.Type(col.Type)).
+			SetContextLength(col.ContextLength)
+
+		if col.Source != "" && col.FillMode == "pick" {
+			if _, ok := sources[col.Source]; ok {
+				cc.SetSource(col.Source).SetRandom(col.Random).
+					SetReplacement(col.Replacement).
+					SetRepeat(col.Repeat).SetLinkedColumn(col.LinkedColumn).
+					SetLinkedContextColumns(col.LinkedContextColumns)
+			} else {
+				return "", ent.Rollback(tx, fmt.Errorf("source %s not dound", col.Source))
+			}
+		}
+		columnCreates = append(columnCreates, cc)
+		t.logger.Debugw(
+			"upserting column", "name", col.Name, "description", col.Description,
+			"fill_mode", col.FillMode, "type", col.Type, "source", col.Source,
+		)
+	}
+
+	err = tx.TableColumn.CreateBulk(columnCreates...).OnConflictColumns(tablecolumn.FieldNanoid).UpdateNewValues().Exec(ctx)
+	if err != nil {
+		return "", ent.Rollback(tx, err)
+	}
+
+	// update rows if exists
+	rows, err := dbtable.QueryRows().All(ctx)
+	if err != nil {
+		return "", ent.Rollback(tx, err)
+	}
+	updates := []*ent.TableRowCreate{}
+	for _, row := range rows {
+		cells := []*schema.CellValue{}
+		for i, cell := range row.Cells {
+			if !removed[i] {
+				cells = append(cells, cell)
+			}
+		}
+		for _, v := range zeros {
+			cells = append(cells, &schema.CellValue{Value: v})
+		}
+		updates = append(updates, tx.TableRow.Create().SetTablemeta(dbtable).SetCells(cells).SetNanoid(row.Nanoid))
+	}
+	if len(updates) > 0 {
+		err = tx.TableRow.CreateBulk(updates...).OnConflictColumns(tablerow.FieldNanoid).UpdateNewValues().Exec(ctx)
+		if err != nil {
+			return "", ent.Rollback(tx, err)
+		}
+	}
+
+	t.logger.Debug("finish updating table")
+	return dbtable.Nanoid, tx.Commit()
 }
 
 func (t *TableServiceImpl) ListTables(ctx context.Context) (*ListTablesResponse, error) {

--- a/services/table/table_moq.go
+++ b/services/table/table_moq.go
@@ -21,11 +21,11 @@ var _ TableService = &TableServiceMock{}
 //
 //		// make and configure a mocked TableService
 //		mockedTableService := &TableServiceMock{
+//			CreateFunc: func(ctx context.Context, req *TableGenRequest) (string, error) {
+//				panic("mock out the Create method")
+//			},
 //			CreateRowsFunc: func(ctx context.Context, table string, rows []map[string]any) error {
 //				panic("mock out the CreateRows method")
-//			},
-//			CreateTableFunc: func(ctx context.Context, req *TableGenRequest) (string, error) {
-//				panic("mock out the CreateTable method")
 //			},
 //			DeleteFunc: func(ctx context.Context, table string) (int, error) {
 //				panic("mock out the Delete method")
@@ -51,6 +51,9 @@ var _ TableService = &TableServiceMock{}
 //			TruncateFunc: func(ctx context.Context, table string) (int, error) {
 //				panic("mock out the Truncate method")
 //			},
+//			UpdateFunc: func(ctx context.Context, table string, req *TableGenRequest) (string, error) {
+//				panic("mock out the Update method")
+//			},
 //		}
 //
 //		// use mockedTableService in code that requires TableService
@@ -58,11 +61,11 @@ var _ TableService = &TableServiceMock{}
 //
 //	}
 type TableServiceMock struct {
+	// CreateFunc mocks the Create method.
+	CreateFunc func(ctx context.Context, req *TableGenRequest) (string, error)
+
 	// CreateRowsFunc mocks the CreateRows method.
 	CreateRowsFunc func(ctx context.Context, table string, rows []map[string]any) error
-
-	// CreateTableFunc mocks the CreateTable method.
-	CreateTableFunc func(ctx context.Context, req *TableGenRequest) (string, error)
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(ctx context.Context, table string) (int, error)
@@ -88,8 +91,18 @@ type TableServiceMock struct {
 	// TruncateFunc mocks the Truncate method.
 	TruncateFunc func(ctx context.Context, table string) (int, error)
 
+	// UpdateFunc mocks the Update method.
+	UpdateFunc func(ctx context.Context, table string, req *TableGenRequest) (string, error)
+
 	// calls tracks calls to the methods.
 	calls struct {
+		// Create holds details about calls to the Create method.
+		Create []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Req is the req argument value.
+			Req *TableGenRequest
+		}
 		// CreateRows holds details about calls to the CreateRows method.
 		CreateRows []struct {
 			// Ctx is the ctx argument value.
@@ -98,13 +111,6 @@ type TableServiceMock struct {
 			Table string
 			// Rows is the rows argument value.
 			Rows []map[string]any
-		}
-		// CreateTable holds details about calls to the CreateTable method.
-		CreateTable []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Req is the req argument value.
-			Req *TableGenRequest
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
@@ -160,9 +166,18 @@ type TableServiceMock struct {
 			// Table is the table argument value.
 			Table string
 		}
+		// Update holds details about calls to the Update method.
+		Update []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Table is the table argument value.
+			Table string
+			// Req is the req argument value.
+			Req *TableGenRequest
+		}
 	}
+	lockCreate         sync.RWMutex
 	lockCreateRows     sync.RWMutex
-	lockCreateTable    sync.RWMutex
 	lockDelete         sync.RWMutex
 	lockGenetate       sync.RWMutex
 	lockGetTableDetail sync.RWMutex
@@ -171,6 +186,43 @@ type TableServiceMock struct {
 	lockRows           sync.RWMutex
 	lockSharedSources  sync.RWMutex
 	lockTruncate       sync.RWMutex
+	lockUpdate         sync.RWMutex
+}
+
+// Create calls CreateFunc.
+func (mock *TableServiceMock) Create(ctx context.Context, req *TableGenRequest) (string, error) {
+	if mock.CreateFunc == nil {
+		panic("TableServiceMock.CreateFunc: method is nil but TableService.Create was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Req *TableGenRequest
+	}{
+		Ctx: ctx,
+		Req: req,
+	}
+	mock.lockCreate.Lock()
+	mock.calls.Create = append(mock.calls.Create, callInfo)
+	mock.lockCreate.Unlock()
+	return mock.CreateFunc(ctx, req)
+}
+
+// CreateCalls gets all the calls that were made to Create.
+// Check the length with:
+//
+//	len(mockedTableService.CreateCalls())
+func (mock *TableServiceMock) CreateCalls() []struct {
+	Ctx context.Context
+	Req *TableGenRequest
+} {
+	var calls []struct {
+		Ctx context.Context
+		Req *TableGenRequest
+	}
+	mock.lockCreate.RLock()
+	calls = mock.calls.Create
+	mock.lockCreate.RUnlock()
+	return calls
 }
 
 // CreateRows calls CreateRowsFunc.
@@ -210,42 +262,6 @@ func (mock *TableServiceMock) CreateRowsCalls() []struct {
 	mock.lockCreateRows.RLock()
 	calls = mock.calls.CreateRows
 	mock.lockCreateRows.RUnlock()
-	return calls
-}
-
-// CreateTable calls CreateTableFunc.
-func (mock *TableServiceMock) CreateTable(ctx context.Context, req *TableGenRequest) (string, error) {
-	if mock.CreateTableFunc == nil {
-		panic("TableServiceMock.CreateTableFunc: method is nil but TableService.CreateTable was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-		Req *TableGenRequest
-	}{
-		Ctx: ctx,
-		Req: req,
-	}
-	mock.lockCreateTable.Lock()
-	mock.calls.CreateTable = append(mock.calls.CreateTable, callInfo)
-	mock.lockCreateTable.Unlock()
-	return mock.CreateTableFunc(ctx, req)
-}
-
-// CreateTableCalls gets all the calls that were made to CreateTable.
-// Check the length with:
-//
-//	len(mockedTableService.CreateTableCalls())
-func (mock *TableServiceMock) CreateTableCalls() []struct {
-	Ctx context.Context
-	Req *TableGenRequest
-} {
-	var calls []struct {
-		Ctx context.Context
-		Req *TableGenRequest
-	}
-	mock.lockCreateTable.RLock()
-	calls = mock.calls.CreateTable
-	mock.lockCreateTable.RUnlock()
 	return calls
 }
 
@@ -530,6 +546,46 @@ func (mock *TableServiceMock) TruncateCalls() []struct {
 	mock.lockTruncate.RLock()
 	calls = mock.calls.Truncate
 	mock.lockTruncate.RUnlock()
+	return calls
+}
+
+// Update calls UpdateFunc.
+func (mock *TableServiceMock) Update(ctx context.Context, table string, req *TableGenRequest) (string, error) {
+	if mock.UpdateFunc == nil {
+		panic("TableServiceMock.UpdateFunc: method is nil but TableService.Update was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Table string
+		Req   *TableGenRequest
+	}{
+		Ctx:   ctx,
+		Table: table,
+		Req:   req,
+	}
+	mock.lockUpdate.Lock()
+	mock.calls.Update = append(mock.calls.Update, callInfo)
+	mock.lockUpdate.Unlock()
+	return mock.UpdateFunc(ctx, table, req)
+}
+
+// UpdateCalls gets all the calls that were made to Update.
+// Check the length with:
+//
+//	len(mockedTableService.UpdateCalls())
+func (mock *TableServiceMock) UpdateCalls() []struct {
+	Ctx   context.Context
+	Table string
+	Req   *TableGenRequest
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Table string
+		Req   *TableGenRequest
+	}
+	mock.lockUpdate.RLock()
+	calls = mock.calls.Update
+	mock.lockUpdate.RUnlock()
 	return calls
 }
 

--- a/services/table/table_test.go
+++ b/services/table/table_test.go
@@ -57,7 +57,7 @@ func toCells(data []any) []*schema.CellValue {
 	return cells
 }
 
-func TestTableService_CreateTable(t *testing.T) {
+func TestTableService_Create(t *testing.T) {
 	db := db.NewTestDB()
 	ctx := context.Background()
 	columns := []TableGenColumn{
@@ -154,7 +154,7 @@ func TestTableService_CreateTable(t *testing.T) {
 		"users":     []byte(fmt.Sprintf(`{"type":"linked","table":"%s"}`, userTable.Nanoid)),
 	}
 
-	id, err := srv.CreateTable(ctx, &TableGenRequest{
+	id, err := srv.Create(ctx, &TableGenRequest{
 		Name:        "test",
 		Description: "test table",
 		Columns:     columns,
@@ -262,7 +262,7 @@ func TestTableService_CreateTableSharedSource(t *testing.T) {
 	).Save(ctx)
 	require.NoError(t, err)
 
-	id, err := srv.CreateTable(ctx, &TableGenRequest{
+	id, err := srv.Create(ctx, &TableGenRequest{
 		Name:        "test",
 		Description: "test table",
 		Columns:     columns,
@@ -758,7 +758,7 @@ func TestTableService_CreateTableAPIRequest(t *testing.T) {
 			).Save(ctx)
 			require.NoError(t, err)
 
-			_, err = srv.CreateTable(ctx, &TableGenRequest{
+			_, err = srv.Create(ctx, &TableGenRequest{
 				Name:        "test",
 				Description: "test table",
 				Columns:     columns,
@@ -779,7 +779,7 @@ func TestTableService_ImportLinked(t *testing.T) {
 	srv, err := NewTableService(&config.Config{Common: config.Common{SourceDataDir: "./"}}, db, nil, zap.NewNop().Sugar())
 	require.NoError(t, err)
 
-	tid, err := srv.CreateTable(ctx, &TableGenRequest{Name: "lt", Columns: []TableGenColumn{
+	tid, err := srv.Create(ctx, &TableGenRequest{Name: "lt", Columns: []TableGenColumn{
 		{Name: "c1", FillMode: "ai", Type: "string", Description: "c1c1"},
 		{Name: "c2", FillMode: "ai", Type: "string", Description: "c2c2"},
 	}})
@@ -863,5 +863,107 @@ func TestTableService_ImportLinked(t *testing.T) {
 			"c2": map[string]any{"data": "bar", "description": "c2c2"},
 		}}},
 		{&schema.CellValue{Value: "c", ContextValue: nil}, &schema.CellValue{Value: "cc", ContextValue: nil}},
+	}, rows)
+}
+
+func TestTableService_Update(t *testing.T) {
+	db := db.NewTestDB()
+	ctx := context.Background()
+	columns := []TableGenColumn{
+		{
+			Name: "name", Description: "recipe name", Type: "string",
+			FillMode: "ai", ContextLength: 5,
+		},
+		{
+			Name: "description", Description: "recipe description", Type: "string",
+			FillMode: "ai", ContextLength: 5,
+		},
+		{
+			Name: "steps", Description: "recipe steps", Type: "string",
+			FillMode: "ai", ContextLength: 3,
+		},
+		{
+			Name: "ingredients", Description: "recipe ingredients", Type: "string",
+			FillMode: "ai",
+		},
+	}
+	srv, err := NewTableService(&config.Config{}, db, nil, zap.NewNop().Sugar())
+	require.NoError(t, err)
+
+	id, err := srv.Create(ctx, &TableGenRequest{
+		Name:        "test",
+		Description: "test table",
+		Columns:     columns,
+		Model:       "aiai",
+	})
+	require.NoError(t, err)
+	detail, err := srv.GetTableDetail(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, []TableColumnInfo{
+		{ID: "UkLWZg", Name: "name", Description: "recipe name", Type: "string", FillMode: "ai"},
+		{ID: "gbHJdm", Name: "description", Description: "recipe description", Type: "string", FillMode: "ai"},
+		{ID: "EfhxLZ", Name: "steps", Description: "recipe steps", Type: "string", FillMode: "ai"},
+		{ID: "VqXmZF", Name: "ingredients", Description: "recipe ingredients", Type: "string", FillMode: "ai"},
+	}, detail.Columns)
+	err = srv.CreateRows(ctx, id, []map[string]any{
+		{"name": "r1", "description": "d1", "steps": "s1", "ingredients": "i1"},
+		{"name": "r2", "description": "d2", "steps": "s2", "ingredients": "i2"},
+	})
+	require.NoError(t, err)
+
+	// change order, remove one column and add two columns
+	columns = []TableGenColumn{
+		{
+			Name: "steps", Description: "recipe steps", Type: "string",
+			FillMode: "ai", ContextLength: 3,
+		},
+		{
+			Name: "ingredients", Description: "recipe ingredients", Type: "string",
+			FillMode: "ai",
+		},
+		{
+			Name: "name", Description: "recipe name", Type: "string",
+			FillMode: "ai", ContextLength: 5,
+		},
+		{
+			Name: "tags", Description: "recipe tags", Type: "string",
+			FillMode: "ai",
+		},
+		{
+			Name: "difficulty", Description: "recipe difficulty", Type: "integer",
+			FillMode: "ai",
+		},
+	}
+	id, err = srv.Update(ctx, "test", &TableGenRequest{
+		Name:        "test_go",
+		Description: "test table go",
+		Columns:     columns,
+	})
+	require.NoError(t, err)
+	detail, err = srv.GetTableDetail(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, []TableColumnInfo{
+		{ID: "UkLWZg", Name: "name", Description: "recipe name", Type: "string", FillMode: "ai"},
+		{ID: "EfhxLZ", Name: "steps", Description: "recipe steps", Type: "string", FillMode: "ai"},
+		{ID: "VqXmZF", Name: "ingredients", Description: "recipe ingredients", Type: "string", FillMode: "ai"},
+		{ID: "p6klVe", Name: "tags", Description: "recipe tags", Type: "string", FillMode: "ai"},
+		{ID: "nJqfPa", Name: "difficulty", Description: "recipe difficulty", Type: "integer", FillMode: "ai"},
+	}, detail.Columns)
+
+	dbrows, err := db.TableRow.Query().Where(tablerow.HasTablemetaWith(tablemeta.Nanoid(id))).Order(ent.Asc("id")).All(ctx)
+	require.NoError(t, err)
+	rows := [][]*schema.CellValue{}
+	for _, row := range dbrows {
+		rows = append(rows, row.Cells)
+	}
+	require.Equal(t, [][]*schema.CellValue{
+		{
+			&schema.CellValue{Value: "r1"}, &schema.CellValue{Value: "s1"},
+			&schema.CellValue{Value: "i1"}, &schema.CellValue{Value: ""}, &schema.CellValue{Value: float64(0)},
+		},
+		{
+			&schema.CellValue{Value: "r2"}, &schema.CellValue{Value: "s2"},
+			&schema.CellValue{Value: "i2"}, &schema.CellValue{Value: ""}, &schema.CellValue{Value: float64(0)},
+		},
 	}, rows)
 }

--- a/services/table/table_test.go
+++ b/services/table/table_test.go
@@ -914,7 +914,7 @@ func TestTableService_Update(t *testing.T) {
 	// change order, remove one column and add two columns
 	columns = []TableGenColumn{
 		{
-			Name: "steps", Description: "recipe steps", Type: "string",
+			Name: "steps", Description: "recipe steps go", Type: "array",
 			FillMode: "ai", ContextLength: 3,
 		},
 		{
@@ -944,7 +944,7 @@ func TestTableService_Update(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []TableColumnInfo{
 		{ID: "UkLWZg", Name: "name", Description: "recipe name", Type: "string", FillMode: "ai"},
-		{ID: "EfhxLZ", Name: "steps", Description: "recipe steps", Type: "string", FillMode: "ai"},
+		{ID: "EfhxLZ", Name: "steps", Description: "recipe steps go", Type: "array", FillMode: "ai"},
 		{ID: "VqXmZF", Name: "ingredients", Description: "recipe ingredients", Type: "string", FillMode: "ai"},
 		{ID: "p6klVe", Name: "tags", Description: "recipe tags", Type: "string", FillMode: "ai"},
 		{ID: "nJqfPa", Name: "difficulty", Description: "recipe difficulty", Type: "integer", FillMode: "ai"},

--- a/services/table/util/convert_type.go
+++ b/services/table/util/convert_type.go
@@ -10,22 +10,26 @@ import (
 	"github.com/spf13/cast"
 )
 
+func ZeroValue(tp tablecolumn.Type) (any, error) {
+	switch tp {
+	case tablecolumn.TypeString:
+		return "", nil
+	case tablecolumn.TypeNumber:
+		return 0.0, nil
+	case tablecolumn.TypeInteger:
+		return 0, nil
+	case tablecolumn.TypeBoolean:
+		return false, nil
+	case tablecolumn.TypeArray:
+		return []any{}, nil
+	default:
+		return "", errors.New("unsupported type")
+	}
+}
+
 func ConvertStringToType(v string, to tablecolumn.Type) (any, error) {
 	if v == "" {
-		switch to {
-		case tablecolumn.TypeString:
-			return "", nil
-		case tablecolumn.TypeNumber:
-			return 0.0, nil
-		case tablecolumn.TypeInteger:
-			return 0, nil
-		case tablecolumn.TypeBoolean:
-			return false, nil
-		case tablecolumn.TypeArray:
-			return []any{}, nil
-		default:
-			return nil, errors.New("unsupported type")
-		}
+		return ZeroValue(to)
 	}
 
 	switch to {


### PR DESCRIPTION
Added a new CLI command:  
```
tablepilot update recipes.json -t=recipes
```  

With this command, you no longer need to manually delete and recreate a table just to add or remove columns.  

The `update` command compares(by name) the existing columns in the database with those in the JSON schema and updates them accordingly:  
- Columns present in both the database and JSON file will be updated.  
- Columns missing from the JSON file will be removed.  
- If the table already contains data:  
  - Removed columns will have their data deleted.  
  - Newly added columns will be initialized with their zero value.  

#### Use Case  
Imagine you’ve created a `recipes` table and generated some rows of data. Now, you want to add a new column while keeping the existing data and autofilling the new column.

Without the `update` command, you would need to:
1. Export existing data to a CSV.
2. Delete the table.
3. Recreate the table using the updated schema.
4. Import data from the CSV.
5. Autofill the new column.

With the `update` command, the process is much simpler:
1. Run the `update` command.
2. Autofill the new column.