### PR TITLE
Rename client to provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To start, first you need to prepare a toml config file. Below is an example `con
 driver = "sqlite3"
 dsn = "data.db?_pragma=foreign_keys(1)"
 
-[[clients]]
+[[providers]]
 name = "gemini"
 type = "openai"
 key = "your_api_key"
@@ -65,7 +65,7 @@ base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 [[models]]
 model = "gemini-2.0-flash-001"
-client = "gemini"
+provider = "gemini"
 rpm = 20
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,14 +25,14 @@ type Model struct {
 	Model     string
 	MaxTokens int64 `mapstructure:"max_tokens"`
 	Alias     string
-	Client    string
+	Provider  string
 	RPM       int
 	Image     bool
 }
 
-type Client interface{}
+type Provider any
 
-type BasicClient struct {
+type BasicProvider struct {
 	Name string
 	Type string
 }
@@ -51,12 +51,12 @@ type Gemini struct {
 }
 
 type Config struct {
-	Common   Common
-	Server   Server
-	Database *Database
-	Models   []Model
-	Clients  []Client
-	Sources  []map[string]any
+	Common    Common
+	Server    Server
+	Database  *Database
+	Models    []Model
+	Providers []Provider
+	Sources   []map[string]any
 }
 
 func NewConfig(name string) (config *Config, err error) {
@@ -66,14 +66,14 @@ func NewConfig(name string) (config *Config, err error) {
 	if err != nil {
 		return config, err
 	}
-	var bc []BasicClient
-	err = viper.UnmarshalKey("clients", &bc)
+	var bc []BasicProvider
+	err = viper.UnmarshalKey("providers", &bc)
 	if err != nil {
 		return config, err
 	}
-	var clients []Client
+	var providers []Provider
 	for i, client := range bc {
-		key := fmt.Sprintf("clients.%d", i)
+		key := fmt.Sprintf("providers.%d", i)
 		switch client.Type {
 		case "openai":
 			var oai OpenAI
@@ -81,14 +81,14 @@ func NewConfig(name string) (config *Config, err error) {
 			if err != nil {
 				return config, err
 			}
-			clients = append(clients, &oai)
+			providers = append(providers, &oai)
 		case "gemini":
 			var genai Gemini
 			err = viper.UnmarshalKey(key, &genai)
 			if err != nil {
 				return config, err
 			}
-			clients = append(clients, &genai)
+			providers = append(providers, &genai)
 		default:
 			return nil, errors.New("unknown client")
 		}
@@ -98,7 +98,7 @@ func NewConfig(name string) (config *Config, err error) {
 	if err != nil {
 		return nil, err
 	}
-	config.Clients = clients
+	config.Providers = providers
 	if config.Server.Address == "" {
 		config.Server.Address = ":8080"
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,7 @@ import (
 func TestConfig_New(t *testing.T) {
 	cfg, err := NewConfig("test.toml")
 	require.NoError(t, err)
-	clientA, ok := cfg.Clients[0].(*OpenAI)
+	clientA, ok := cfg.Providers[0].(*OpenAI)
 	require.True(t, ok)
 	require.Equal(t, &OpenAI{
 		Name:    "gemini",
@@ -17,7 +17,7 @@ func TestConfig_New(t *testing.T) {
 		Key:     "a",
 		BaseURL: "urla",
 	}, clientA)
-	clientB, ok := cfg.Clients[1].(*OpenAI)
+	clientB, ok := cfg.Providers[1].(*OpenAI)
 	require.True(t, ok)
 	require.Equal(t, &OpenAI{
 		Name:    "oai",
@@ -29,13 +29,13 @@ func TestConfig_New(t *testing.T) {
 		Default:   true,
 		Model:     "gemini-2.0-flash-001",
 		MaxTokens: 1200,
-		Client:    "gemini",
+		Provider:  "gemini",
 		RPM:       10,
 	}, cfg.Models[0])
 	require.Equal(t, Model{
-		Model:  "gpt-4o",
-		Alias:  "gpt4o",
-		Client: "oai",
-		RPM:    5,
+		Model:    "gpt-4o",
+		Alias:    "gpt4o",
+		Provider: "oai",
+		RPM:      5,
 	}, cfg.Models[1])
 }

--- a/config/test.toml
+++ b/config/test.toml
@@ -4,13 +4,13 @@ debug = false
 driver = "sqlite3"
 dsn = "data.db?_pragma=foreign_keys(1)"
 
-[[clients]]
+[[providers]]
 name = "gemini"
 type = "openai"
 key = "a"
 base_url = "urla"
 
-[[clients]]
+[[providers]]
 name = "oai"
 type = "openai"
 key = "b"
@@ -18,7 +18,7 @@ base_url = "urlb"
 
 [[models]]
 model = "gemini-2.0-flash-001"
-client = "gemini"
+provider = "gemini"
 default = true
 max_tokens = 1200
 rpm = 10
@@ -26,5 +26,5 @@ rpm = 10
 [[models]]
 model = "gpt-4o"
 alias = "gpt4o"
-client = "oai"
+provider = "oai"
 rpm = 5

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -27,23 +27,23 @@ driver = "sqlite3"
 dsn = "data.db?_pragma=foreign_keys(1)"
 ```
 
-### Clients
+### Providers
 
-You can define multiple clients, and different models can use different clients.
+You can define multiple providers, and different models can use different providers.
 
-- **name**: The name of the client. This name is referenced in the `models` section to select which client the model uses.
-- **type**: The client type. Currently, `"openai"` and `"gemini"`(experimental and only usable for image generation) is supported. `openai` type should includes all OpenAI-compatible APIs.
+- **name**: The name of the provider. This name is referenced in the `models` section to select which provider the model uses.
+- **type**: The provider type. Currently, `"openai"` and `"gemini"`(experimental and only usable for image generation) is supported. `openai` type should includes all OpenAI-compatible APIs.
 - **key**: The API key used to authenticate requests.
 - **base_url**: The base URL of the API.
 
 ```toml
-[[clients]]
+[[providers]]
 name = "gemini"
 type = "openai"
 key = "your_api_key"
 base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
-[[clients]]
+[[providers]]
 name = "openai"
 type = "openai"
 key = "your_api_key"
@@ -63,11 +63,11 @@ address = ":8088"
 
 ### Models
 
-You can define multiple models and assign them to different clients or different generations.
+You can define multiple models and assign them to different providers or different generations.
 
 - **model**: The name of the model as used in the LLM API (e.g., `"gemini-2.0-flash-001"`).
 - **alias**: An alias for the model (e.g., `"gemini-pro"`). This allows you to upgrade the model without changing the alias in the table JSON schema, making it easier to manage. Optional.
-- **client**: The name of the client to be used for this model (must match a name from the `clients` section).
+- **provider**: The name of the provider to be used for this model (must match a name from the `providers` section).
 - **default**: Set to `true` if this is the default model. Only one model can be set as `default`. If no model is marked as `default`, the first model in the list will be used. The default model is used when no specific model is provided in the table JSON schema or the `--model` flag. Optional.
 - **max_tokens**: The maximum number of tokens that can be generated in the chat completion (default 6000). Optional.
 - **rpm**: The rate limit for this model, specified in requests per minute. This is used to control the rate of API calls and enforce a model-specific rate limiter (default no limit). Optional.
@@ -77,12 +77,12 @@ You can define multiple models and assign them to different clients or different
 ```toml
 [[models]]
 model = "gemini-2.0-flash-001"
-client = "gemini"
+provider = "gemini"
 rpm = 20
 
 [[models]]
 model = "gpt-4o"
-client = "openai"
+provider = "openai"
 rpm = 5
 ```
 

--- a/examples/100_recipes/README.md
+++ b/examples/100_recipes/README.md
@@ -30,26 +30,27 @@ dsn = "data.db?_pragma=foreign_keys(1)"
 [server]
 address = ":8080"
 
-[[clients]]
+[[providers]]
 name = "gemini"
 type = "openai"
 key = ""
 base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
-[[clients]]
+[[providers]]
 name = "gemini-image"
 type = "gemini"
 key = ""
 
 [[models]]
 model = "gemini-2.0-flash-001"
-client = "gemini"
+provider = "gemini"
 rpm = 10
 
-[[image_models]]
+[[models]]
 model = "gemini-2.0-flash-exp-image-generation"
-client = "gemini-image"
+provider = "gemini-image"
 rpm = 10
+image = true
 ```
 
 Make sure to replace the `key` with your Gemini key. Both models should be free to use. Save this configuration to a file named `config.toml` in your current working directory.

--- a/examples/recipes_with_image/README.md
+++ b/examples/recipes_with_image/README.md
@@ -33,29 +33,30 @@ dsn = "data.db?_pragma=foreign_keys(1)"
 [server]
 address = ":8080"
 
-[[clients]]
+[[providers]]
 name = "gemini"
 type = "openai"
 key = "key"
 base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
 
-[[clients]]
+[[providers]]
 name = "gemini-image"
 type = "gemini"
 key = "key"
 
 [[models]]
 model = "gemini-2.0-flash-001"
-client = "gemini"
+provider = "gemini"
 rpm = 10
 
-[[image_models]]
+[[models]]
 model = "gemini-2.0-flash-exp-image-generation"
-client = "gemini-image"
+provider = "gemini-image"
 rpm = 10
+image = true
 ```
 
-The client type must be `gemini` and the model must be `gemini-2.0-flash-exp-image-generation`. Once configured, Tablepilot will use this image model when generating images. The generated images will be saved in the `{source_data_dir}/tablepilot_images/{table_id}` directory.
+The provider type must be `gemini` and the model must be `gemini-2.0-flash-exp-image-generation`. Once configured, Tablepilot will use this image model when generating images. The generated images will be saved in the `{source_data_dir}/tablepilot_images/{table_id}` directory.
 
 **View Generated Images in Real Time**
 

--- a/services/provider/provider.go
+++ b/services/provider/provider.go
@@ -147,7 +147,7 @@ func (p *ProviderServiceImpl) genProviders(ctx context.Context) ([]Provider, err
 	// add providers from config file
 	providers := []Provider{}
 	pm := map[string]int{}
-	for i, c := range p.cfg.Clients {
+	for i, c := range p.cfg.Providers {
 		switch v := c.(type) {
 		case *config.OpenAI:
 			providers = append(providers, Provider{
@@ -171,12 +171,12 @@ func (p *ProviderServiceImpl) genProviders(ctx context.Context) ([]Provider, err
 		}
 	}
 	for _, m := range p.cfg.Models {
-		if ic, ok := pm[m.Client]; ok {
+		if ic, ok := pm[m.Provider]; ok {
 			md := Model{
 				Model:     m.Model,
 				MaxTokens: m.MaxTokens,
 				Alias:     m.Alias,
-				Client:    m.Client,
+				Client:    m.Provider,
 				Rpm:       m.RPM,
 				Image:     m.Image,
 				Default:   m.Default,

--- a/services/provider/provider_test.go
+++ b/services/provider/provider_test.go
@@ -151,7 +151,7 @@ func TestProviderService_DeleteProvider(t *testing.T) {
 func TestProviderService_genProviders(t *testing.T) {
 	db := db.NewTestDB()
 	srv := NewProviderService(&config.Config{
-		Clients: []config.Client{
+		Providers: []config.Provider{
 			&config.OpenAI{
 				Name:    "p1",
 				Key:     "k",
@@ -160,9 +160,9 @@ func TestProviderService_genProviders(t *testing.T) {
 			},
 		},
 		Models: []config.Model{
-			{Model: "m", Alias: "ma", Client: "p1", MaxTokens: 100, RPM: 5},
-			{Model: "m2", Alias: "ma2", Client: "p1", MaxTokens: 200, RPM: 25},
-			{Model: "mi", Alias: "mia", Client: "p1", MaxTokens: 10, RPM: 3, Image: true},
+			{Model: "m", Alias: "ma", Provider: "p1", MaxTokens: 100, RPM: 5},
+			{Model: "m2", Alias: "ma2", Provider: "p1", MaxTokens: 200, RPM: 25},
+			{Model: "mi", Alias: "mia", Provider: "p1", MaxTokens: 10, RPM: 3, Image: true},
 		},
 	}, db, zap.NewNop().Sugar())
 	err := srv.CreateProvider(context.TODO(), Provider{

--- a/tests/cli/test.toml
+++ b/tests/cli/test.toml
@@ -7,7 +7,7 @@ dsn = "test.db?_pragma=foreign_keys(1)"
 [server]
 address = ":8080"
 
-[[clients]]
+[[providers]]
 name = "openai"
 type = "openai"
 key = "abc"
@@ -15,5 +15,5 @@ base_url = "https://models.inference.ai.azure.com"
 
 [[models]]
 model = "gemini-2.0-flash-001"
-client = "openai"
+provider = "openai"
 rpm = 10

--- a/ui/src/actions.ts
+++ b/ui/src/actions.ts
@@ -176,6 +176,7 @@ export interface ModelListItem {
 
 export interface ModelList {
   default_model: string;
+  default_image_model: string;
   models: ModelListItem[];
 }
 

--- a/ui/src/components/dialog/providers.tsx
+++ b/ui/src/components/dialog/providers.tsx
@@ -135,7 +135,7 @@ export function ProvidersListDialog({
                     <TableCell className="w-[30%] truncate">
                       {provider.base_url}
                     </TableCell>
-                    <TableCell>{provider.models.length}</TableCell>
+                    <TableCell>{provider.models?.length ?? 0}</TableCell>
                     <TableCell>
                       <div className="flex justify-end space-x-2">
                         <Button

--- a/ui/src/components/table.test.tsx
+++ b/ui/src/components/table.test.tsx
@@ -60,6 +60,7 @@ describe("Table", () => {
     const mockedGetModels = vi.mocked(getModels);
     mockedGetModels.mockResolvedValue({
       default_model: "ai",
+      default_image_model: "",
       models: [
         { name: "ai", image: false },
         { name: "bi", image: false },

--- a/ui/src/components/table.tsx
+++ b/ui/src/components/table.tsx
@@ -258,7 +258,7 @@ export function Table({ id }: TableProps) {
       }
       setModel(currentModel);
       genRequestRef.current.model = currentModel;
-      let currentImageModel = models.default_image_model;
+      const currentImageModel = models.default_image_model;
       setImageModel(currentImageModel);
       genRequestRef.current.image_model = currentImageModel;
       setModels(models);

--- a/ui/src/components/table.tsx
+++ b/ui/src/components/table.tsx
@@ -258,6 +258,9 @@ export function Table({ id }: TableProps) {
       }
       setModel(currentModel);
       genRequestRef.current.model = currentModel;
+      let currentImageModel = models.default_image_model;
+      setImageModel(currentImageModel);
+      genRequestRef.current.image_model = currentImageModel;
       setModels(models);
       setRows(vm);
       setLoading(false);


### PR DESCRIPTION
Rename clients/client to providers/provider in config file to maintain consistency with the provider configuration used in the WebUI and app.