### PR TITLE
[Jules] Refactor workflow builder and validate vars

### DIFF
--- a/.vite/results.json
+++ b/.vite/results.json
@@ -1,0 +1,1 @@
+{"version":"3.1.4","results":[[":ui/src/components/dialog/workflow/builder.test.tsx",{"duration":0,"failed":true}]]}

--- a/.vite/results.json
+++ b/.vite/results.json
@@ -1,1 +1,0 @@
-{"version":"3.1.4","results":[[":ui/src/components/dialog/workflow/builder.test.tsx",{"duration":0,"failed":true}]]}

--- a/ui/src/components/dialog/workflow/builder.test.tsx
+++ b/ui/src/components/dialog/workflow/builder.test.tsx
@@ -243,9 +243,10 @@ describe("Workflow Builder", () => {
     await userEvent.click(fileVarSelect);
     const fileVarListbox = await screen.findByRole("listbox");
     await userEvent.click(within(fileVarListbox).getByText("importFileVar"));
-    const input = screen.getAllByPlaceholderText(
-      "Type @ to mention a variable...",
-    )[0];
+    // Updated placeholder for New Table Name in ImportStep
+    const input = screen.getByPlaceholderText(
+      "Enter new table name or use @ for variables",
+    );
     await userEvent.type(input, "ImportedTable");
     const promptInput = screen.getByPlaceholderText(
       "Used only when importing images, as AI is required to extract data from them.",
@@ -339,7 +340,8 @@ describe("Workflow Builder", () => {
   it("ExportTable action should correctly save workflow", async () => {
     await userEvent.click(screen.getByText("Add Step"));
     await userEvent.click(screen.getByText("Export Data"));
-    await userEvent.click(screen.getByText("Select a table").parentElement!);
+    // Updated placeholder text for ExportTableStep
+    await userEvent.click(screen.getByText("Select a table to export").parentElement!);
     const tablesBox = await screen.findByRole("listbox");
     await userEvent.click(within(tablesBox).getByText("recipes"));
     await userEvent.click(screen.getByText("Save Workflow"));
@@ -409,5 +411,95 @@ describe("Workflow Builder", () => {
     expect(payload.prompt).toBe("Autofill recipe names");
     expect(payload.count).toBe(30);
     expect(payload.batch).toBe(3);
+  });
+});
+
+describe("Workflow Builder - UserInput Variable Name Validation", () => {
+  beforeEach(async () => {
+    // Common setup for these validation tests
+    const mockedGetTables = vi.mocked(getTables);
+    mockedGetTables.mockResolvedValue({ tables: [], total: 0 }); // No tables needed for these tests
+    vi.mock("@/actions"); // Reset mocks
+
+    render(
+      <TestProvider>
+        <WorkflowBuilderDialog
+          open={true}
+          onOpenChange={() => {}}
+          onSave={async () => {}}
+        />
+      </TestProvider>,
+    );
+    await screen.findByText("Workflow Steps"); // Ensure dialog is loaded
+
+    // Select UserInput step and add a variable
+    await userEvent.click(screen.getAllByText("UserInput")[0]);
+    await userEvent.click(screen.getByText("Add Variable"));
+    // Ensure "Variable 1" is present before each test case proceeds
+    await screen.findByText("Variable 1");
+  });
+
+  it("should allow valid alphanumeric name", async () => {
+    const variableNameInput = screen.getByPlaceholderText("e.g. tableName");
+    await userEvent.type(variableNameInput, "TestVar123");
+    await userEvent.click(screen.getByText("Save Workflow"));
+
+    const wf = vi.mocked(createWorkflow).mock.calls[0][0];
+    expect(wf.variables[0].name).toBe("TestVar123");
+  });
+
+  it("should prevent spaces in name", async () => {
+    const variableNameInput = screen.getByPlaceholderText("e.g. tableName");
+    await userEvent.type(variableNameInput, "Test Var 123"); // Type with spaces
+    await userEvent.click(screen.getByText("Save Workflow"));
+
+    const wf = vi.mocked(createWorkflow).mock.calls[0][0];
+    expect(wf.variables[0].name).toBe("TestVar123"); // Spaces should be ignored
+  });
+
+  it("should prevent special characters in name", async () => {
+    const variableNameInput = screen.getByPlaceholderText("e.g. tableName");
+    await userEvent.type(variableNameInput, "Test@Var!"); // Type with special chars
+    await userEvent.click(screen.getByText("Save Workflow"));
+
+    const wf = vi.mocked(createWorkflow).mock.calls[0][0];
+    expect(wf.variables[0].name).toBe("TestVar"); // Special chars should be ignored
+  });
+
+  it("should handle mixed valid and invalid characters", async () => {
+    const variableNameInput = screen.getByPlaceholderText("e.g. tableName");
+    await userEvent.type(variableNameInput, "Alpha1-Beta2="); // Mixed
+    await userEvent.click(screen.getByText("Save Workflow"));
+
+    const wf = vi.mocked(createWorkflow).mock.calls[0][0];
+    expect(wf.variables[0].name).toBe("Alpha1Beta2"); // Invalid chars ignored
+  });
+
+  it("should allow empty name after typing and deleting", async () => {
+    const variableNameInput = screen.getByPlaceholderText("e.g. tableName");
+    await userEvent.type(variableNameInput, "abc");
+    await userEvent.clear(variableNameInput);
+    await userEvent.click(screen.getByText("Save Workflow"));
+
+    const wf = vi.mocked(createWorkflow).mock.calls[0][0];
+    expect(wf.variables[0].name).toBe("");
+  });
+  
+  it("should filter leading and trailing invalid characters", async () => {
+    const variableNameInput = screen.getByPlaceholderText("e.g. tableName");
+    await userEvent.type(variableNameInput, "!@#Valid$%\^");
+    await userEvent.click(screen.getByText("Save Workflow"));
+
+    const wf = vi.mocked(createWorkflow).mock.calls[0][0];
+    expect(wf.variables[0].name).toBe("Valid");
+  });
+
+  it("should result in an empty name if only invalid characters are typed", async () => {
+    const variableNameInput = screen.getByPlaceholderText("e.g. tableName");
+    await userEvent.type(variableNameInput, "!@#$%^");
+    await userEvent.click(screen.getByText("Save Workflow"));
+    
+    const wf = vi.mocked(createWorkflow).mock.calls[0][0];
+    expect(wf.variables[0].name).toBe("");
   });
 });

--- a/ui/src/components/dialog/workflow/builder.tsx
+++ b/ui/src/components/dialog/workflow/builder.tsx
@@ -19,7 +19,7 @@ import {
     Workflow,
     WorkflowStepType,
     WorkflowVariable,
-    WorkflowVariableType,
+    // WorkflowVariableType, // Removed as per lint error
     createWorkflow,
     getTables,
     tableCreateRequestToTableInfo,
@@ -44,13 +44,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 // import { NumberInput } from "@/components/ui/number-input"; // Removed, handled by step components
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
+// import { // Removed as per lint error
+// Select,
+// SelectContent,
+// SelectItem,
+// SelectTrigger,
+// SelectValue,
+// } from "@/components/ui/select";
 // import { ContextVariable, MentionInput } from "@/components/ui/var-input"; // Removed, handled by step components
 import { ContextVariable } from "@/components/ui/var-input"; // Keep ContextVariable if StepContext uses it
 import { DialogTitle } from "@radix-ui/react-dialog";

--- a/ui/src/components/dialog/workflow/builder.tsx
+++ b/ui/src/components/dialog/workflow/builder.tsx
@@ -3,9 +3,7 @@ import {
     ChevronUp,
     Pencil,
     Plus,
-    PlusCircle,
     Trash2,
-    X,
 } from "lucide-react";
 
 import { useEffect, useRef, useState } from "react";
@@ -28,7 +26,7 @@ import {
     updateWorkflow,
 } from "@/actions";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox"; // Added Checkbox import
+// import { Checkbox } from "@/components/ui/checkbox"; // Checkbox will be removed if not used elsewhere
 import {
     Dialog,
     DialogContent,
@@ -44,7 +42,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { NumberInput } from "@/components/ui/number-input";
+// import { NumberInput } from "@/components/ui/number-input"; // Removed, handled by step components
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
     Select,
@@ -53,11 +51,20 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { ContextVariable, MentionInput } from "@/components/ui/var-input";
+// import { ContextVariable, MentionInput } from "@/components/ui/var-input"; // Removed, handled by step components
+import { ContextVariable } from "@/components/ui/var-input"; // Keep ContextVariable if StepContext uses it
 import { DialogTitle } from "@radix-ui/react-dialog";
-import { AutofillInput } from "../autofill-input";
-import { CreateTableDialog } from "../create-table";
+// import { AutofillInput } from "../autofill-input"; // Removed, handled by AutofillStep
+import { UserInputStep } from "./steps/userInputStep"; // Import the new component
+import { CreateTableStep } from "./steps/createTableStep"; // Import the new component
+import { DeleteTableStep } from "./steps/deleteTableStep"; // Import the new component
+import { CreateColumnStep } from "./steps/createColumnStep"; // Import the new component
+import { DeleteColumnStep } from "./steps/deleteColumnStep"; // Import the new component
+import { ImportStep } from "./steps/importStep"; // Import the new component
+import { GenerateStep } from "./steps/generateStep"; // Import the new component
+import { AutofillStep } from "./steps/autofillStep"; // Import the new component
+import { ExportTableStep } from "./steps/exportTableStep"; // Import the new component
+// import { CreateTableDialog } from "../create-table"; // Removed CreateTableDialog import
 
 interface StepContext {
   variables: ContextVariable[];
@@ -85,7 +92,7 @@ export default function WorkflowBuilderDialog({
     null,
   );
   const [stepContexts, setStepContexts] = useState<StepContext[]>([]);
-  const [createTableDialogOpen, setCreateTableDialogOpen] = useState(false);
+  // const [createTableDialogOpen, setCreateTableDialogOpen] = useState(false); // Removed state
   const existingTables = useRef<TableInfo[]>([]);
 
   const fetchTables = async () => {
@@ -593,863 +600,110 @@ export default function WorkflowBuilderDialog({
                     </div>
 
                     {/* UserInput properties */}
-                    {selectedStep.type === "UserInput" && (
-                      <div className="space-y-4">
-                        <p className="text-xs">
-                          This step lets you add variables used in the workflow.
-                          When creating other steps, you can type '@' to
-                          reference any variables defined here. When the
-                          workflow starts, you’ll be prompted to input or select
-                          values for all variables first.
-                        </p>
-                        <div className="flex justify-between items-center">
-                          <Label>Variables</Label>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={addVariable}
-                            className="flex items-center gap-1"
-                          >
-                            <PlusCircle className="h-3.5 w-3.5" /> Add Variable
-                          </Button>
-                        </div>
-
-                        {selectedStep.payload.variables.length === 0 ? (
-                          <div className="text-center p-4 border rounded-md text-muted-foreground">
-                            No variables defined. Click "Add Variable" to create
-                            one.
-                          </div>
-                        ) : (
-                          <div className="space-y-4">
-                            {selectedStep.payload.variables.map(
-                              (variable, idx) => (
-                                <div
-                                  key={idx}
-                                  className="p-3 border rounded-md space-y-3"
-                                >
-                                  <div className="flex justify-between items-center">
-                                    <h4 className="font-medium">
-                                      Variable {idx + 1}
-                                    </h4>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      onClick={() => removeVariable(idx)}
-                                    >
-                                      <X className="h-4 w-4 text-muted-foreground" />
-                                    </Button>
-                                  </div>
-
-                                  <div className="space-y-2">
-                                    <Label htmlFor={`var-name-${idx}`}>
-                                      Name
-                                    </Label>
-                                    <Input
-                                      id={`var-name-${idx}`}
-                                      value={variable.name}
-                                      onChange={(e) =>
-                                        updateVariable(idx, {
-                                          ...variable,
-                                          name: e.target.value,
-                                        })
-                                      }
-                                      placeholder="e.g. tableName"
-                                    />
-                                  </div>
-
-                                  <div className="space-y-2">
-                                    <Label htmlFor={`var-type-${idx}`}>
-                                      Type
-                                    </Label>
-                                    <Select
-                                      value={variable.type}
-                                      onValueChange={(
-                                        value: WorkflowVariableType,
-                                      ) =>
-                                        updateVariable(idx, {
-                                          ...variable,
-                                          type: value,
-                                        })
-                                      }
-                                    >
-                                      <SelectTrigger id={`var-type-${idx}`}>
-                                        <SelectValue placeholder="Select type" />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="string">
-                                          String
-                                        </SelectItem>
-                                        <SelectItem value="integer">
-                                          Integer
-                                        </SelectItem>
-                                        <SelectItem value="number">
-                                          Number
-                                        </SelectItem>
-                                        <SelectItem value="file">
-                                          File
-                                        </SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                  </div>
-
-                                  {variable.type !== "file" && (
-                                    <div className="space-y-2">
-                                      <Label htmlFor={`var-default-${idx}`}>
-                                        Default Value
-                                      </Label>
-                                      <MentionInput
-                                        id={`var-default-${idx}`}
-                                        value={variable.default_value}
-                                        onChange={(v) =>
-                                          updateVariable(idx, {
-                                            ...variable,
-                                            default_value: v.target.value,
-                                          })
-                                        }
-                                        placeholder={
-                                          variable.type === "string"
-                                            ? 'e.g. "users"'
-                                            : variable.type === "number"
-                                              ? "e.g. 3.14"
-                                              : variable.type === "integer"
-                                                ? "e.g. 20"
-                                                : 'e.g. {"key": "value"}'
-                                        }
-                                      />
-                                    </div>
-                                  )}
-
-                                  {variable.type !== "file" && (
-                                    <div className="space-y-2">
-                                      <Label htmlFor={`var-options-${idx}`}>
-                                        Options (optional, one per line)
-                                      </Label>
-                                      <Textarea
-                                        id={`var-options-${idx}`}
-                                        defaultValue={variable.options.join(
-                                          "\n",
-                                        )}
-                                        onChange={(e) => {
-                                          updateVariable(idx, {
-                                            ...variable,
-                                            options: e.target.value
-                                              .split("\n")
-                                              .filter(
-                                                (opt) => opt.trim() !== "",
-                                              ),
-                                          });
-                                        }}
-                                        className="w-full min-h-[100px] p-2 border rounded-md"
-                                        placeholder="Enter options, one per line, will select one option when workflow start instead input value manually."
-                                      />
-                                    </div>
-                                  )}
-                                </div>
-                              ),
-                            )}
-                          </div>
-                        )}
-                      </div>
+                    {selectedStep.type === "UserInput" && selectedStepIndex !== null && (
+                      <UserInputStep
+                        step={selectedStep.payload as UserInputStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "UserInput", payload })
+                        }
+                        onAddVariable={addVariable}
+                        onUpdateVariable={updateVariable}
+                        onRemoveVariable={removeVariable}
+                      />
                     )}
 
                     {/* CreateTable properties */}
-                    {selectedStep.type === "CreateTable" && (
-                      <div>
-                        <div className="flex flex-row mb-5 items-center">
-                          <div className="w-24">
-                            <Label htmlFor="onExists">On Exists</Label>
-                          </div>
-                          <Select
-                            value={selectedStep.payload.on_exists}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  on_exists: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="onExists">
-                              <SelectValue placeholder="What to do if table exists" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="Stop">
-                                Stop workflow
-                              </SelectItem>
-                              <SelectItem value="Recreate">
-                                Recreate the table
-                              </SelectItem>
-                              <SelectItem value="Skip">
-                                Do nothing and continue
-                              </SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <CreateTableDialog
-                          variables={stepContexts[selectedStepIndex!].variables}
-                          isOpen={createTableDialogOpen}
-                          setIsOpen={setCreateTableDialogOpen}
-                          close={() => {}}
-                          form={selectedStep.payload.request}
-                          onSave={(v) => {
-                            updateStep({
-                              type: selectedStep.type,
-                              payload: {
-                                ...selectedStep.payload,
-                                request: v,
-                              },
-                            });
-                            setCreateTableDialogOpen(false);
-                          }}
-                        />
-                        <div
-                          className="border rounded-lg p-4 cursor-pointer hover:bg-muted/50 transition-colors"
-                          onClick={() => setCreateTableDialogOpen(true)}
-                        >
-                          <div className="flex items-center justify-between mb-2">
-                            <h3 className="font-medium">Table Configuration</h3>
-                            <Pencil className="h-4 w-4 text-muted-foreground" />
-                          </div>
-                          <div className="space-y-2 text-sm">
-                            <div className="flex items-center gap-2">
-                              <span className="text-muted-foreground">
-                                Name:
-                              </span>
-                              <span>
-                                {selectedStep.payload.request.name ||
-                                  "Unnamed Table"}
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              <span className="text-muted-foreground">
-                                Description:
-                              </span>
-                              <span>
-                                {selectedStep.payload.request.description ||
-                                  "No description"}
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              <span className="text-muted-foreground">
-                                Columns:
-                              </span>
-                              <span>
-                                {selectedStep.payload.request.columns.length}{" "}
-                                columns
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              <span className="text-muted-foreground">
-                                Sources:
-                              </span>
-                              <span>
-                                {selectedStep.payload.request.sources.length}{" "}
-                                sources
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
+                    {selectedStep.type === "CreateTable" && selectedStepIndex !== null && (
+                      <CreateTableStep
+                        step={selectedStep.payload as CreateTableStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "CreateTable", payload })
+                        }
+                      />
                     )}
 
                     {/* DeleteTable properties */}
-                    {selectedStep.type === "DeleteTable" && (
-                      <div className="space-y-2">
-                        <Label htmlFor="tableName">Table Name</Label>
-                        <Select
-                          value={selectedStep.payload.table}
-                          onValueChange={(value) =>
-                            updateStep({
-                              type: selectedStep.type,
-                              payload: {
-                                ...selectedStep.payload,
-                                table: value,
-                              },
-                            })
-                          }
-                        >
-                          <SelectTrigger id="tables">
-                            <SelectValue placeholder="Select a table" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {stepContexts[selectedStepIndex!].tables.map(
-                              (t) => (
-                                <SelectItem value={t.id}>{t.name}</SelectItem>
-                              ),
-                            )}
-                          </SelectContent>
-                        </Select>
-                      </div>
+                    {selectedStep.type === "DeleteTable" && selectedStepIndex !== null && (
+                     <DeleteTableStep
+                        step={selectedStep.payload as DeleteTableStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "DeleteTable", payload })
+                        }
+                      />
                     )}
 
                     {/* CreateColumn properties */}
-                    {selectedStep.type === "CreateColumn" && (
-                      <div key={selectedStepIndex}>
-                        <div className="space-y-2">
-                          <Label htmlFor="tableName">Table Name</Label>
-                          <Select
-                            value={selectedStep.payload.table}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  table: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="tables">
-                              <SelectValue placeholder="Select a table" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {stepContexts[selectedStepIndex!].tables.map(
-                                (t, i) => (
-                                  <SelectItem value={t.id} key={i}>
-                                    {t.name}
-                                  </SelectItem>
-                                ),
-                              )}
-                            </SelectContent>
-                          </Select>
-                        </div>
-
-                        <div className="space-y-2">
-                          <Label htmlFor="columnName">Column Name</Label>
-                          <MentionInput
-                            id="columnName"
-                            variables={
-                              stepContexts[selectedStepIndex!].variables
-                            }
-                            value={selectedStep.payload.name}
-                            onChange={(e) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  name: e.target.value,
-                                },
-                              })
-                            }
-                          />
-                        </div>
-                        <div className="space-y-2">
-                          <Label htmlFor="columnDescription">
-                            Column Description
-                          </Label>
-                          <MentionInput
-                            id="columnDescription"
-                            variables={
-                              stepContexts[selectedStepIndex!].variables
-                            }
-                            value={selectedStep.payload.description}
-                            onChange={(e) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  description: e.target.value,
-                                },
-                              })
-                            }
-                          />
-                        </div>
-                        <div className="space-y-2">
-                          <Label htmlFor="dataType">Data Type</Label>
-                          <Select
-                            value={selectedStep.payload.type}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  type: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="dataType">
-                              <SelectValue placeholder="Select data type" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="string">String</SelectItem>
-                              <SelectItem value="integer">Integer</SelectItem>
-                              <SelectItem value="number">Number</SelectItem>
-                              <SelectItem value="image">Image</SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      </div>
+                    {selectedStep.type === "CreateColumn" && selectedStepIndex !== null && (
+                      <CreateColumnStep
+                        step={selectedStep.payload as CreateColumnStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "CreateColumn", payload })
+                        }
+                      />
                     )}
 
                     {/* DeleteColumn properties */}
-                    {selectedStep.type === "DeleteColumn" && (
-                      <>
-                        <div className="space-y-2">
-                          <Label htmlFor="tableName">Table Name</Label>
-                          <Select
-                            value={selectedStep.payload.table}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  table: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="tables">
-                              <SelectValue placeholder="Select a table" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {stepContexts[selectedStepIndex!].tables.map(
-                                (t) => (
-                                  <SelectItem value={t.id}>{t.name}</SelectItem>
-                                ),
-                              )}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <div className="space-y-2">
-                          <Label htmlFor="columnName">Column</Label>
-                          <Select
-                            value={selectedStep.payload.column}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  column: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="column">
-                              <SelectValue placeholder="Select a column" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {(
-                                stepContexts[selectedStepIndex!].tables.find(
-                                  (t) => t.id === selectedStep.payload.table,
-                                )?.columns ?? []
-                              ).map((c) => (
-                                <SelectItem value={c.id}>{c.name}</SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      </>
+                    {selectedStep.type === "DeleteColumn" && selectedStepIndex !== null && (
+                      <DeleteColumnStep
+                        step={selectedStep.payload as DeleteColumnStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "DeleteColumn", payload })
+                        }
+                      />
                     )}
 
                     {/* Generate properties */}
-                    {selectedStep.type === "Generate" && (
-                      <>
-                        <div className="space-y-2">
-                          <Label htmlFor="tableName">Table Name</Label>
-                          <Select
-                            value={selectedStep.payload.table}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  table: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="tables">
-                              <SelectValue placeholder="Select a table" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {stepContexts[selectedStepIndex!].tables.map(
-                                (t) => (
-                                  <SelectItem value={t.id}>{t.name}</SelectItem>
-                                ),
-                              )}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <div className="space-y-2">
-                          <Label htmlFor="GenerateCount">Count</Label>
-                          <NumberInput
-                            id="GenerateCount"
-                            value={selectedStep.payload.count}
-                            onValueChange={(e) => {
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  count: e ?? 0,
-                                },
-                              });
-                            }}
-                          />
-                        </div>
-                        <div className="space-y-2">
-                          <Label htmlFor="GenerateBatch">Batch</Label>
-                          <NumberInput
-                            id="GenerateBatch"
-                            value={selectedStep.payload.batch}
-                            onValueChange={(e) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  batch: e ?? 0,
-                                },
-                              })
-                            }
-                          />
-                        </div>
-                      </>
+                    {selectedStep.type === "Generate" && selectedStepIndex !== null && (
+                      <GenerateStep
+                        step={selectedStep.payload as GenerateStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "Generate", payload })
+                        }
+                      />
                     )}
 
                     {/* Autofill properties */}
-                    {selectedStep.type === "Autofill" && (
-                      <>
-                        <div className="space-y-2">
-                          <Label htmlFor="tableName">Table Name</Label>
-                          <Select
-                            value={selectedStep.payload.table}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  table: value,
-                                  columns: [],
-                                  context_columns: [],
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="tables">
-                              <SelectValue placeholder="Select a table" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {stepContexts[selectedStepIndex!].tables.map(
-                                (t) => (
-                                  <SelectItem value={t.id}>{t.name}</SelectItem>
-                                ),
-                              )}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        <AutofillInput
-                          allColumns={
-                            stepContexts[selectedStepIndex!].tables.find(
-                              (t) => t.id === selectedStep.payload.table,
-                            )?.columns ?? []
-                          }
-                          variables={stepContexts[selectedStepIndex!].variables}
-                          columns={selectedStep.payload.columns}
-                          contextColumns={selectedStep.payload.context_columns}
-                          prompt={selectedStep.payload.prompt}
-                          onColumnsChange={(v) => {
-                            updateStep({
-                              type: selectedStep.type,
-                              payload: {
-                                ...selectedStep.payload,
-                                columns: [...v],
-                              },
-                            });
-                          }}
-                          onContextColumnsChange={(v) => {
-                            updateStep({
-                              type: selectedStep.type,
-                              payload: {
-                                ...selectedStep.payload,
-                                context_columns: [...v],
-                              },
-                            });
-                          }}
-                          onPromptChange={(v) => {
-                            updateStep({
-                              type: selectedStep.type,
-                              payload: {
-                                ...selectedStep.payload,
-                                prompt: v,
-                              },
-                            });
-                          }}
-                        />
-                        <div className="flex flex-row items-center space-x-4">
-                          <div className="flex flex-row items-center space-x-2">
-                            <Label htmlFor="GenerateCount">Count</Label>
-                            <NumberInput
-                              id="GenerateCount"
-                              value={selectedStep.payload.count}
-                              onValueChange={(e) =>
-                                updateStep({
-                                  type: selectedStep.type,
-                                  payload: {
-                                    ...selectedStep.payload,
-                                    count: e ?? 0,
-                                  },
-                                })
-                              }
-                            />
-                          </div>
-                          <div className="flex flex-row items-center space-x-2">
-                            <Label htmlFor="GenerateBatch">Batch</Label>
-                            <NumberInput
-                              id="GenerateBatch"
-                              value={selectedStep.payload.batch}
-                              onValueChange={(e) =>
-                                updateStep({
-                                  type: selectedStep.type,
-                                  payload: {
-                                    ...selectedStep.payload,
-                                    batch: e ?? 0,
-                                  },
-                                })
-                              }
-                            />
-                          </div>
-                        </div>
-                      </>
+                    {selectedStep.type === "Autofill" && selectedStepIndex !== null && (
+                      <AutofillStep
+                        step={selectedStep.payload as AutofillStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "Autofill", payload })
+                        }
+                      />
                     )}
 
                     {/* ImportData properties */}
-                    {selectedStep.type === "Import" && (
-                      <div className="space-y-4">
-                        {" "}
-                        {/* Increased spacing */}
-                        {/* File Variable Select */}
-                        <div className="space-y-2">
-                          <Label htmlFor="importFile">File</Label>
-                          <Select
-                            value={
-                              (selectedStep.payload as ImportDataStepPayload)
-                                .file
-                            }
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...(selectedStep.payload as ImportDataStepPayload),
-                                  file: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="importFile">
-                              <SelectValue placeholder="Select file" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {stepContexts[1].variables
-                                .filter((v) => v.type === "file")
-                                .map((v, idx) => (
-                                  <SelectItem key={idx} value={v.path}>
-                                    {v.display}
-                                  </SelectItem>
-                                ))}
-                            </SelectContent>
-                          </Select>
-                          <p className="text-xs text-primary/80">
-                            You can select any file-type variable defined in the
-                            UserInput step here. When the workflow starts, the
-                            user will be prompted to select the file first.
-                          </p>
-                        </div>
-                        {/* Import Option Select */}
-                        <div className="space-y-2">
-                          <Label htmlFor="importOption">Import Option</Label>
-                          <Select
-                            value={
-                              (selectedStep.payload as ImportDataStepPayload)
-                                .table === ""
-                                ? "Create new table"
-                                : "Import into existing table"
-                            }
-                            onValueChange={(value) => {
-                              const newPayload = {
-                                ...(selectedStep.payload as ImportDataStepPayload),
-                                importOption: value,
-                              };
-                              if (value === "Create new table") {
-                                newPayload.table = "";
-                                newPayload.truncate = false;
-                              } else {
-                                // "Import into existing table"
-                                newPayload.name = "";
-                                newPayload.table = "__select__";
-                              }
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: newPayload,
-                              });
-                            }}
-                          >
-                            <SelectTrigger id="importOption">
-                              <SelectValue placeholder="Select import option" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="Create new table">
-                                Create new table
-                              </SelectItem>
-                              <SelectItem value="Import into existing table">
-                                Import into existing table
-                              </SelectItem>
-                            </SelectContent>
-                          </Select>
-                        </div>
-                        {/* Conditional Fields */}
-                        {(selectedStep.payload as ImportDataStepPayload)
-                          .table === "" && (
-                          <div className="space-y-2">
-                            <Label htmlFor="newTableName">New Table Name</Label>
-                            <MentionInput
-                              id="newTableName"
-                              variables={
-                                stepContexts[selectedStepIndex!].variables
-                              }
-                              value={
-                                (selectedStep.payload as ImportDataStepPayload)
-                                  .name ?? ""
-                              }
-                              onChange={(e) =>
-                                updateStep({
-                                  type: selectedStep.type,
-                                  payload: {
-                                    ...(selectedStep.payload as ImportDataStepPayload),
-                                    name: e.target.value,
-                                  },
-                                })
-                              }
-                            />
-                          </div>
-                        )}
-                        {(selectedStep.payload as ImportDataStepPayload)
-                          .table !== "" && (
-                          <>
-                            <div className="space-y-2">
-                              <Label htmlFor="existingTableName">
-                                Select Table
-                              </Label>
-                              <Select
-                                value={
-                                  (
-                                    selectedStep.payload as ImportDataStepPayload
-                                  ).table ?? ""
-                                }
-                                onValueChange={(value) =>
-                                  updateStep({
-                                    type: selectedStep.type,
-                                    payload: {
-                                      ...(selectedStep.payload as ImportDataStepPayload),
-                                      table: value,
-                                    },
-                                  })
-                                }
-                              >
-                                <SelectTrigger id="existingTableName">
-                                  <SelectValue placeholder="Select existing table" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {stepContexts[selectedStepIndex!].tables.map(
-                                    (t) => (
-                                      <SelectItem key={t.id} value={t.id}>
-                                        {t.name}
-                                      </SelectItem>
-                                    ),
-                                  )}
-                                </SelectContent>
-                              </Select>
-                            </div>
-                            <div className="flex items-center space-x-2 mt-2">
-                              <Checkbox
-                                id="truncateTable"
-                                checked={
-                                  (
-                                    selectedStep.payload as ImportDataStepPayload
-                                  ).truncate
-                                }
-                                onCheckedChange={(checked) =>
-                                  updateStep({
-                                    type: selectedStep.type,
-                                    payload: {
-                                      ...(selectedStep.payload as ImportDataStepPayload),
-                                      truncate: !!checked,
-                                    },
-                                  })
-                                }
-                              />
-                              <Label
-                                htmlFor="truncateTable"
-                                className="cursor-pointer"
-                              >
-                                Truncate table before import
-                              </Label>
-                            </div>
-                          </>
-                        )}
-                        {/* Prompt */}
-                        <div className="space-y-2">
-                          <Label htmlFor="importPrompt">
-                            Prompt (Import Image)
-                          </Label>
-                          <MentionInput
-                            id="importPrompt"
-                            className="mt-2"
-                            textarea={true}
-                            rows={3}
-                            placeholder="Used only when importing images, as AI is required to extract data from them."
-                            value={
-                              (selectedStep.payload as ImportDataStepPayload)
-                                .prompt
-                            }
-                            variables={
-                              stepContexts[selectedStepIndex!].variables
-                            }
-                            onChange={(e) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...(selectedStep.payload as ImportDataStepPayload),
-                                  prompt: e.target.value,
-                                },
-                              })
-                            }
-                          />
-                        </div>
-                      </div>
+                    {selectedStep.type === "Import" && selectedStepIndex !== null && stepContexts[0] && (
+                      <ImportStep
+                        step={selectedStep.payload as ImportDataStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        allUserInputVariables={ (steps[0].payload as UserInputStepPayload).variables.map(v => ({
+                          display: v.name,
+                          path: v.name,
+                          type: v.type,
+                        }))}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "Import", payload })
+                        }
+                      />
                     )}
 
                     {/* Export properties */}
-                    {selectedStep.type === "ExportTable" && (
-                      <div>
-                        <div className="space-y-2">
-                          <Label htmlFor="tableName">Table Name</Label>
-                          <Select
-                            value={selectedStep.payload.table}
-                            onValueChange={(value) =>
-                              updateStep({
-                                type: selectedStep.type,
-                                payload: {
-                                  ...selectedStep.payload,
-                                  table: value,
-                                },
-                              })
-                            }
-                          >
-                            <SelectTrigger id="tables">
-                              <SelectValue placeholder="Select a table" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {stepContexts[selectedStepIndex!].tables.map(
-                                (t) => (
-                                  <SelectItem value={t.id}>{t.name}</SelectItem>
-                                ),
-                              )}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      </div>
+                    {selectedStep.type === "ExportTable" && selectedStepIndex !== null && (
+                      <ExportTableStep
+                        step={selectedStep.payload as ExportStepPayload}
+                        context={stepContexts[selectedStepIndex]}
+                        onUpdateStep={(payload) =>
+                          updateStep({ type: "ExportTable", payload })
+                        }
+                      />
                     )}
                   </div>
                 ) : (

--- a/ui/src/components/dialog/workflow/builder.tsx
+++ b/ui/src/components/dialog/workflow/builder.tsx
@@ -1,10 +1,4 @@
-import {
-    ChevronDown,
-    ChevronUp,
-    Pencil,
-    Plus,
-    Trash2,
-} from "lucide-react";
+import { ChevronDown, ChevronUp, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { useEffect, useRef, useState } from "react";
 
@@ -19,14 +13,12 @@ import {
     Workflow,
     WorkflowStepType,
     WorkflowVariable,
-    // WorkflowVariableType, // Removed as per lint error
     createWorkflow,
     getTables,
     tableCreateRequestToTableInfo,
     updateWorkflow,
 } from "@/actions";
 import { Button } from "@/components/ui/button";
-// import { Checkbox } from "@/components/ui/checkbox"; // Checkbox will be removed if not used elsewhere
 import {
     Dialog,
     DialogContent,
@@ -42,31 +34,20 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-// import { NumberInput } from "@/components/ui/number-input"; // Removed, handled by step components
 import { ScrollArea } from "@/components/ui/scroll-area";
-// import { // Removed as per lint error
-// Select,
-// SelectContent,
-// SelectItem,
-// SelectTrigger,
-// SelectValue,
-// } from "@/components/ui/select";
-// import { ContextVariable, MentionInput } from "@/components/ui/var-input"; // Removed, handled by step components
-import { ContextVariable } from "@/components/ui/var-input"; // Keep ContextVariable if StepContext uses it
+import { ContextVariable } from "@/components/ui/var-input";
 import { DialogTitle } from "@radix-ui/react-dialog";
-// import { AutofillInput } from "../autofill-input"; // Removed, handled by AutofillStep
-import { UserInputStep } from "./steps/userInputStep"; // Import the new component
-import { CreateTableStep } from "./steps/createTableStep"; // Import the new component
-import { DeleteTableStep } from "./steps/deleteTableStep"; // Import the new component
-import { CreateColumnStep } from "./steps/createColumnStep"; // Import the new component
-import { DeleteColumnStep } from "./steps/deleteColumnStep"; // Import the new component
-import { ImportStep } from "./steps/importStep"; // Import the new component
-import { GenerateStep } from "./steps/generateStep"; // Import the new component
-import { AutofillStep } from "./steps/autofillStep"; // Import the new component
-import { ExportTableStep } from "./steps/exportTableStep"; // Import the new component
-// import { CreateTableDialog } from "../create-table"; // Removed CreateTableDialog import
+import { AutofillStep } from "./steps/autofillStep";
+import { CreateColumnStep } from "./steps/createColumnStep";
+import { CreateTableStep } from "./steps/createTableStep";
+import { DeleteColumnStep } from "./steps/deleteColumnStep";
+import { DeleteTableStep } from "./steps/deleteTableStep";
+import { ExportTableStep } from "./steps/exportTableStep";
+import { GenerateStep } from "./steps/generateStep";
+import { ImportStep } from "./steps/importStep";
+import { UserInputStep } from "./steps/userInputStep";
 
-interface StepContext {
+export interface StepContext {
   variables: ContextVariable[];
   tables: TableInfo[];
 }
@@ -600,111 +581,120 @@ export default function WorkflowBuilderDialog({
                     </div>
 
                     {/* UserInput properties */}
-                    {selectedStep.type === "UserInput" && selectedStepIndex !== null && (
-                      <UserInputStep
-                        step={selectedStep.payload as UserInputStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "UserInput", payload })
-                        }
-                        onAddVariable={addVariable}
-                        onUpdateVariable={updateVariable}
-                        onRemoveVariable={removeVariable}
-                      />
-                    )}
+                    {selectedStep.type === "UserInput" &&
+                      selectedStepIndex !== null && (
+                        <UserInputStep
+                          step={selectedStep.payload as UserInputStepPayload}
+                          context={stepContexts[selectedStepIndex]}
+                          onAddVariable={addVariable}
+                          onUpdateVariable={updateVariable}
+                          onRemoveVariable={removeVariable}
+                        />
+                      )}
 
                     {/* CreateTable properties */}
-                    {selectedStep.type === "CreateTable" && selectedStepIndex !== null && (
-                      <CreateTableStep
-                        step={selectedStep.payload as CreateTableStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "CreateTable", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "CreateTable" &&
+                      selectedStepIndex !== null && (
+                        <CreateTableStep
+                          step={selectedStep.payload as CreateTableStepPayload}
+                          context={stepContexts[selectedStepIndex]}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "CreateTable", payload })
+                          }
+                        />
+                      )}
 
                     {/* DeleteTable properties */}
-                    {selectedStep.type === "DeleteTable" && selectedStepIndex !== null && (
-                     <DeleteTableStep
-                        step={selectedStep.payload as DeleteTableStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "DeleteTable", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "DeleteTable" &&
+                      selectedStepIndex !== null && (
+                        <DeleteTableStep
+                          step={selectedStep.payload}
+                          context={stepContexts[selectedStepIndex]}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "DeleteTable", payload })
+                          }
+                        />
+                      )}
 
                     {/* CreateColumn properties */}
-                    {selectedStep.type === "CreateColumn" && selectedStepIndex !== null && (
-                      <CreateColumnStep
-                        step={selectedStep.payload as CreateColumnStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "CreateColumn", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "CreateColumn" &&
+                      selectedStepIndex !== null && (
+                        <CreateColumnStep
+                          step={selectedStep.payload as CreateColumnStepPayload}
+                          context={stepContexts[selectedStepIndex]}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "CreateColumn", payload })
+                          }
+                        />
+                      )}
 
                     {/* DeleteColumn properties */}
-                    {selectedStep.type === "DeleteColumn" && selectedStepIndex !== null && (
-                      <DeleteColumnStep
-                        step={selectedStep.payload as DeleteColumnStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "DeleteColumn", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "DeleteColumn" &&
+                      selectedStepIndex !== null && (
+                        <DeleteColumnStep
+                          step={selectedStep.payload}
+                          context={stepContexts[selectedStepIndex]}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "DeleteColumn", payload })
+                          }
+                        />
+                      )}
 
                     {/* Generate properties */}
-                    {selectedStep.type === "Generate" && selectedStepIndex !== null && (
-                      <GenerateStep
-                        step={selectedStep.payload as GenerateStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "Generate", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "Generate" &&
+                      selectedStepIndex !== null && (
+                        <GenerateStep
+                          step={selectedStep.payload}
+                          context={stepContexts[selectedStepIndex]}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "Generate", payload })
+                          }
+                        />
+                      )}
 
                     {/* Autofill properties */}
-                    {selectedStep.type === "Autofill" && selectedStepIndex !== null && (
-                      <AutofillStep
-                        step={selectedStep.payload as AutofillStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "Autofill", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "Autofill" &&
+                      selectedStepIndex !== null && (
+                        <AutofillStep
+                          step={selectedStep.payload}
+                          context={stepContexts[selectedStepIndex]}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "Autofill", payload })
+                          }
+                        />
+                      )}
 
                     {/* ImportData properties */}
-                    {selectedStep.type === "Import" && selectedStepIndex !== null && stepContexts[0] && (
-                      <ImportStep
-                        step={selectedStep.payload as ImportDataStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        allUserInputVariables={ (steps[0].payload as UserInputStepPayload).variables.map(v => ({
-                          display: v.name,
-                          path: v.name,
-                          type: v.type,
-                        }))}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "Import", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "Import" &&
+                      selectedStepIndex !== null &&
+                      stepContexts[0] && (
+                        <ImportStep
+                          step={selectedStep.payload as ImportDataStepPayload}
+                          context={stepContexts[selectedStepIndex]}
+                          allUserInputVariables={(
+                            steps[0].payload as UserInputStepPayload
+                          ).variables.map((v) => ({
+                            display: v.name,
+                            path: v.name,
+                            type: v.type,
+                          }))}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "Import", payload })
+                          }
+                        />
+                      )}
 
                     {/* Export properties */}
-                    {selectedStep.type === "ExportTable" && selectedStepIndex !== null && (
-                      <ExportTableStep
-                        step={selectedStep.payload as ExportStepPayload}
-                        context={stepContexts[selectedStepIndex]}
-                        onUpdateStep={(payload) =>
-                          updateStep({ type: "ExportTable", payload })
-                        }
-                      />
-                    )}
+                    {selectedStep.type === "ExportTable" &&
+                      selectedStepIndex !== null && (
+                        <ExportTableStep
+                          step={selectedStep.payload}
+                          context={stepContexts[selectedStepIndex]}
+                          onUpdateStep={(payload) =>
+                            updateStep({ type: "ExportTable", payload })
+                          }
+                        />
+                      )}
                   </div>
                 ) : (
                   <div className="text-center p-8 text-muted-foreground">

--- a/ui/src/components/dialog/workflow/steps/autofillStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/autofillStep.tsx
@@ -1,17 +1,14 @@
-import {
-  AutofillStepPayload,
-  // ColumnInfo, // For AutofillInput allColumns - Removed as unused
-} from "@/actions";
+import { AutofillStepPayload } from "@/actions";
 import { Label } from "@/components/ui/label";
 import { NumberInput } from "@/components/ui/number-input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select";
-import { AutofillInput } from "../../autofill-input"; // Corrected path
+import { AutofillInput } from "../../autofill-input";
 import { StepContext } from "../builder";
 
 interface AutofillStepProps {

--- a/ui/src/components/dialog/workflow/steps/autofillStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/autofillStep.tsx
@@ -1,0 +1,111 @@
+import {
+  AutofillStepPayload,
+  ColumnInfo, // For AutofillInput allColumns
+} from "@/actions";
+import { Label } from "@/components/ui/label";
+import { NumberInput } from "@/components/ui/number-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AutofillInput } from "../../autofill-input"; // Corrected path
+import { StepContext } from "../builder";
+
+interface AutofillStepProps {
+  step: AutofillStepPayload;
+  context: StepContext;
+  onUpdateStep: (payload: AutofillStepPayload) => void;
+}
+
+export function AutofillStep({
+  step,
+  context,
+  onUpdateStep,
+}: AutofillStepProps) {
+  const selectedTableInfo = context.tables.find((t) => t.id === step.table);
+
+  const handleTableChange = (tableId: string) => {
+    onUpdateStep({
+      ...step,
+      table: tableId,
+      columns: [], // Reset columns
+      context_columns: [], // Reset context_columns
+    });
+  };
+
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="tableName">Table Name</Label>
+        <Select value={step.table} onValueChange={handleTableChange}>
+          <SelectTrigger id="tables">
+            <SelectValue placeholder="Select a table" />
+          </SelectTrigger>
+          <SelectContent>
+            {context.tables.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <AutofillInput
+        allColumns={selectedTableInfo?.columns ?? []}
+        variables={context.variables}
+        columns={step.columns}
+        contextColumns={step.context_columns}
+        prompt={step.prompt}
+        onColumnsChange={(v) => {
+          onUpdateStep({
+            ...step,
+            columns: [...v],
+          });
+        }}
+        onContextColumnsChange={(v) => {
+          onUpdateStep({
+            ...step,
+            context_columns: [...v],
+          });
+        }}
+        onPromptChange={(v) => {
+          onUpdateStep({
+            ...step,
+            prompt: v,
+          });
+        }}
+      />
+      <div className="flex flex-row items-center space-x-4">
+        <div className="flex flex-row items-center space-x-2">
+          <Label htmlFor="AutofillCount">Count</Label>
+          <NumberInput
+            id="AutofillCount"
+            value={step.count}
+            onValueChange={(value) =>
+              onUpdateStep({
+                ...step,
+                count: value ?? 0,
+              })
+            }
+          />
+        </div>
+        <div className="flex flex-row items-center space-x-2">
+          <Label htmlFor="AutofillBatch">Batch</Label>
+          <NumberInput
+            id="AutofillBatch"
+            value={step.batch}
+            onValueChange={(value) =>
+              onUpdateStep({
+                ...step,
+                batch: value ?? 0,
+              })
+            }
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/autofillStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/autofillStep.tsx
@@ -1,6 +1,6 @@
 import {
   AutofillStepPayload,
-  ColumnInfo, // For AutofillInput allColumns
+  // ColumnInfo, // For AutofillInput allColumns - Removed as unused
 } from "@/actions";
 import { Label } from "@/components/ui/label";
 import { NumberInput } from "@/components/ui/number-input";

--- a/ui/src/components/dialog/workflow/steps/createColumnStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/createColumnStep.tsx
@@ -1,0 +1,104 @@
+import {
+  CreateColumnStepPayload,
+} from "@/actions";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { MentionInput } from "@/components/ui/var-input";
+import { StepContext } from "../builder"; // Import StepContext from builder
+
+interface CreateColumnStepProps {
+  step: CreateColumnStepPayload;
+  context: StepContext;
+  onUpdateStep: (payload: CreateColumnStepPayload) => void;
+}
+
+export function CreateColumnStep({
+  step,
+  context,
+  onUpdateStep,
+}: CreateColumnStepProps) {
+  return (
+    <div className="space-y-2">
+      <div className="space-y-2">
+        <Label htmlFor="tableName">Table Name</Label>
+        <Select
+          value={step.table}
+          onValueChange={(value) =>
+            onUpdateStep({
+              ...step,
+              table: value,
+            })
+          }
+        >
+          <SelectTrigger id="tables">
+            <SelectValue placeholder="Select a table" />
+          </SelectTrigger>
+          <SelectContent>
+            {context.tables.map((t, i) => (
+              <SelectItem value={t.id} key={i}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="columnName">Column Name</Label>
+        <MentionInput
+          id="columnName"
+          variables={context.variables}
+          value={step.name}
+          onChange={(e) =>
+            onUpdateStep({
+              ...step,
+              name: e.target.value,
+            })
+          }
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="columnDescription">Column Description</Label>
+        <MentionInput
+          id="columnDescription"
+          variables={context.variables}
+          value={step.description}
+          onChange={(e) =>
+            onUpdateStep({
+              ...step,
+              description: e.target.value,
+            })
+          }
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="dataType">Data Type</Label>
+        <Select
+          value={step.type}
+          onValueChange={(value) =>
+            onUpdateStep({
+              ...step,
+              type: value,
+            })
+          }
+        >
+          <SelectTrigger id="dataType">
+            <SelectValue placeholder="Select data type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="string">String</SelectItem>
+            <SelectItem value="integer">Integer</SelectItem>
+            <SelectItem value="number">Number</SelectItem>
+            <SelectItem value="image">Image</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/createColumnStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/createColumnStep.tsx
@@ -1,16 +1,14 @@
-import {
-  CreateColumnStepPayload,
-} from "@/actions";
+import { CreateColumnStepPayload } from "@/actions";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select";
 import { MentionInput } from "@/components/ui/var-input";
-import { StepContext } from "../builder"; // Import StepContext from builder
+import { StepContext } from "../builder";
 
 interface CreateColumnStepProps {
   step: CreateColumnStepPayload;

--- a/ui/src/components/dialog/workflow/steps/createTableStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/createTableStep.tsx
@@ -1,20 +1,17 @@
 import { Pencil } from "lucide-react";
 import { useState } from "react";
 
-import {
-  CreateTableStepPayload,
-  TableCreationRequest,
-} from "@/actions";
+import { CreateTableStepPayload } from "@/actions";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select";
 import { CreateTableDialog } from "../../create-table";
-import { StepContext } from "../builder"; // Import StepContext from builder
+import { StepContext } from "../builder";
 
 interface CreateTableStepProps {
   step: CreateTableStepPayload;
@@ -60,7 +57,7 @@ export function CreateTableStep({
         setIsOpen={setCreateTableDialogOpen}
         close={() => {}} // Assuming close can be a no-op if handled by setIsOpen
         form={step.request}
-        onSave={(v: TableCreationRequest) => {
+        onSave={(v) => {
           onUpdateStep({
             ...step,
             request: v,
@@ -83,9 +80,7 @@ export function CreateTableStep({
           </div>
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground">Description:</span>
-            <span>
-              {step.request.description || "No description"}
-            </span>
+            <span>{step.request.description || "No description"}</span>
           </div>
           <div className="flex items-center gap-2">
             <span className="text-muted-foreground">Columns:</span>

--- a/ui/src/components/dialog/workflow/steps/createTableStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/createTableStep.tsx
@@ -1,0 +1,102 @@
+import { Pencil } from "lucide-react";
+import { useState } from "react";
+
+import {
+  CreateTableStepPayload,
+  TableCreationRequest,
+} from "@/actions";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CreateTableDialog } from "../../create-table";
+import { StepContext } from "../builder"; // Import StepContext from builder
+
+interface CreateTableStepProps {
+  step: CreateTableStepPayload;
+  context: StepContext;
+  onUpdateStep: (payload: CreateTableStepPayload) => void;
+}
+
+export function CreateTableStep({
+  step,
+  context,
+  onUpdateStep,
+}: CreateTableStepProps) {
+  const [createTableDialogOpen, setCreateTableDialogOpen] = useState(false);
+
+  return (
+    <div>
+      <div className="flex flex-row mb-5 items-center">
+        <div className="w-24">
+          <Label htmlFor="onExists">On Exists</Label>
+        </div>
+        <Select
+          value={step.on_exists}
+          onValueChange={(value) =>
+            onUpdateStep({
+              ...step,
+              on_exists: value,
+            })
+          }
+        >
+          <SelectTrigger id="onExists">
+            <SelectValue placeholder="What to do if table exists" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Stop">Stop workflow</SelectItem>
+            <SelectItem value="Recreate">Recreate the table</SelectItem>
+            <SelectItem value="Skip">Do nothing and continue</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <CreateTableDialog
+        variables={context.variables}
+        isOpen={createTableDialogOpen}
+        setIsOpen={setCreateTableDialogOpen}
+        close={() => {}} // Assuming close can be a no-op if handled by setIsOpen
+        form={step.request}
+        onSave={(v: TableCreationRequest) => {
+          onUpdateStep({
+            ...step,
+            request: v,
+          });
+          setCreateTableDialogOpen(false);
+        }}
+      />
+      <div
+        className="border rounded-lg p-4 cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={() => setCreateTableDialogOpen(true)}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="font-medium">Table Configuration</h3>
+          <Pencil className="h-4 w-4 text-muted-foreground" />
+        </div>
+        <div className="space-y-2 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Name:</span>
+            <span>{step.request.name || "Unnamed Table"}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Description:</span>
+            <span>
+              {step.request.description || "No description"}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Columns:</span>
+            <span>{step.request.columns.length} columns</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Sources:</span>
+            <span>{step.request.sources.length} sources</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/deleteColumnStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/deleteColumnStep.tsx
@@ -1,0 +1,86 @@
+import {
+  DeleteColumnStepPayload,
+  TableInfo, // Assuming TableInfo is needed for context.tables
+} from "@/actions";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { StepContext } from "../builder"; // Import StepContext from builder
+
+interface DeleteColumnStepProps {
+  step: DeleteColumnStepPayload;
+  context: StepContext;
+  onUpdateStep: (payload: DeleteColumnStepPayload) => void;
+}
+
+export function DeleteColumnStep({
+  step,
+  context,
+  onUpdateStep,
+}: DeleteColumnStepProps) {
+  const selectedTableInfo = context.tables.find((t) => t.id === step.table);
+
+  const handleTableChange = (tableId: string) => {
+    const newTableInfo = context.tables.find((t) => t.id === tableId);
+    let column = step.column;
+    // Reset column if it's not in the new table
+    if (newTableInfo && !newTableInfo.columns.find((c) => c.id === column)) {
+      column = ""; // Or set to a default/placeholder if applicable
+    }
+    onUpdateStep({
+      table: tableId,
+      column: column,
+    });
+  };
+
+  const handleColumnChange = (columnId: string) => {
+    onUpdateStep({
+      ...step,
+      column: columnId,
+    });
+  };
+
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="tableName">Table Name</Label>
+        <Select value={step.table} onValueChange={handleTableChange}>
+          <SelectTrigger id="tables">
+            <SelectValue placeholder="Select a table" />
+          </SelectTrigger>
+          <SelectContent>
+            {context.tables.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="columnName">Column</Label>
+        <Select
+          value={step.column}
+          onValueChange={handleColumnChange}
+          disabled={!step.table} // Disable if no table is selected
+        >
+          <SelectTrigger id="column">
+            <SelectValue placeholder="Select a column" />
+          </SelectTrigger>
+          <SelectContent>
+            {(selectedTableInfo?.columns ?? []).map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/deleteColumnStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/deleteColumnStep.tsx
@@ -1,16 +1,13 @@
-import {
-  DeleteColumnStepPayload,
-  // TableInfo, // Assuming TableInfo is needed for context.tables - Removed as unused
-} from "@/actions";
+import { DeleteColumnStepPayload } from "@/actions";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select";
-import { StepContext } from "../builder"; // Import StepContext from builder
+import { StepContext } from "../builder";
 
 interface DeleteColumnStepProps {
   step: DeleteColumnStepPayload;

--- a/ui/src/components/dialog/workflow/steps/deleteColumnStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/deleteColumnStep.tsx
@@ -1,6 +1,6 @@
 import {
   DeleteColumnStepPayload,
-  TableInfo, // Assuming TableInfo is needed for context.tables
+  // TableInfo, // Assuming TableInfo is needed for context.tables - Removed as unused
 } from "@/actions";
 import { Label } from "@/components/ui/label";
 import {

--- a/ui/src/components/dialog/workflow/steps/deleteTableStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/deleteTableStep.tsx
@@ -1,0 +1,48 @@
+import {
+  DeleteTableStepPayload,
+} from "@/actions";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { StepContext } from "../builder"; // Import StepContext from builder
+
+interface DeleteTableStepProps {
+  step: DeleteTableStepPayload;
+  context: StepContext;
+  onUpdateStep: (payload: DeleteTableStepPayload) => void;
+}
+
+export function DeleteTableStep({
+  step,
+  context,
+  onUpdateStep,
+}: DeleteTableStepProps) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="tableName">Table Name</Label>
+      <Select
+        value={step.table}
+        onValueChange={(value) =>
+          onUpdateStep({
+            ...step,
+            table: value,
+          })
+        }
+      >
+        <SelectTrigger id="tables">
+          <SelectValue placeholder="Select a table" />
+        </SelectTrigger>
+        <SelectContent>
+          {context.tables.map((t) => (
+            <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/deleteTableStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/deleteTableStep.tsx
@@ -1,15 +1,13 @@
-import {
-  DeleteTableStepPayload,
-} from "@/actions";
+import { DeleteTableStepPayload } from "@/actions";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select";
-import { StepContext } from "../builder"; // Import StepContext from builder
+import { StepContext } from "../builder";
 
 interface DeleteTableStepProps {
   step: DeleteTableStepPayload;
@@ -39,7 +37,9 @@ export function DeleteTableStep({
         </SelectTrigger>
         <SelectContent>
           {context.tables.map((t) => (
-            <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+            <SelectItem key={t.id} value={t.id}>
+              {t.name}
+            </SelectItem>
           ))}
         </SelectContent>
       </Select>

--- a/ui/src/components/dialog/workflow/steps/exportTableStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/exportTableStep.tsx
@@ -1,0 +1,52 @@
+import {
+  ExportStepPayload, // Assuming this type exists, if not, it might be ExportTableStepPayload
+} from "@/actions";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { StepContext } from "../builder";
+
+interface ExportTableStepProps {
+  step: ExportStepPayload; // Or ExportTableStepPayload
+  context: StepContext;
+  onUpdateStep: (payload: ExportStepPayload) => void; // Or ExportTableStepPayload
+}
+
+export function ExportTableStep({
+  step,
+  context,
+  onUpdateStep,
+}: ExportTableStepProps) {
+  return (
+    <div>
+      <div className="space-y-2">
+        <Label htmlFor="tableName">Table Name</Label>
+        <Select
+          value={step.table}
+          onValueChange={(value) =>
+            onUpdateStep({
+              ...step,
+              table: value,
+            })
+          }
+        >
+          <SelectTrigger id="tables">
+            <SelectValue placeholder="Select a table to export" />
+          </SelectTrigger>
+          <SelectContent>
+            {context.tables.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/generateStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/generateStep.tsx
@@ -1,14 +1,12 @@
-import {
-  GenerateStepPayload,
-} from "@/actions";
+import { GenerateStepPayload } from "@/actions";
 import { Label } from "@/components/ui/label";
 import { NumberInput } from "@/components/ui/number-input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select";
 import { StepContext } from "../builder";
 

--- a/ui/src/components/dialog/workflow/steps/generateStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/generateStep.tsx
@@ -1,0 +1,79 @@
+import {
+  GenerateStepPayload,
+} from "@/actions";
+import { Label } from "@/components/ui/label";
+import { NumberInput } from "@/components/ui/number-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { StepContext } from "../builder";
+
+interface GenerateStepProps {
+  step: GenerateStepPayload;
+  context: StepContext;
+  onUpdateStep: (payload: GenerateStepPayload) => void;
+}
+
+export function GenerateStep({
+  step,
+  context,
+  onUpdateStep,
+}: GenerateStepProps) {
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="tableName">Table Name</Label>
+        <Select
+          value={step.table}
+          onValueChange={(value) =>
+            onUpdateStep({
+              ...step,
+              table: value,
+            })
+          }
+        >
+          <SelectTrigger id="tables">
+            <SelectValue placeholder="Select a table" />
+          </SelectTrigger>
+          <SelectContent>
+            {context.tables.map((t) => (
+              <SelectItem key={t.id} value={t.id}>
+                {t.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="GenerateCount">Count</Label>
+        <NumberInput
+          id="GenerateCount"
+          value={step.count}
+          onValueChange={(value) => {
+            onUpdateStep({
+              ...step,
+              count: value ?? 0,
+            });
+          }}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="GenerateBatch">Batch</Label>
+        <NumberInput
+          id="GenerateBatch"
+          value={step.batch}
+          onValueChange={(value) =>
+            onUpdateStep({
+              ...step,
+              batch: value ?? 0,
+            })
+          }
+        />
+      </div>
+    </>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/importStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/importStep.tsx
@@ -1,0 +1,192 @@
+import {
+  ImportDataStepPayload,
+} from "@/actions";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { MentionInput, ContextVariable } from "@/components/ui/var-input";
+import { StepContext } from "../builder";
+
+interface ImportStepProps {
+  step: ImportDataStepPayload;
+  context: StepContext; // For current step's variables (prompt) and available tables
+  allUserInputVariables: ContextVariable[]; // For selecting 'file' type variables from UserInput step
+  onUpdateStep: (payload: ImportDataStepPayload) => void;
+}
+
+export function ImportStep({
+  step,
+  context,
+  allUserInputVariables,
+  onUpdateStep,
+}: ImportStepProps) {
+  const handleImportOptionChange = (value: string) => {
+    const newPayload: ImportDataStepPayload = {
+      ...step,
+    };
+    if (value === "Create new table") {
+      newPayload.table = ""; // Reset existing table selection
+      newPayload.truncate = false; // Not applicable for new table
+      // newPayload.name = step.name; // Keep existing name or clear it: ""
+    } else { // "Import into existing table"
+      newPayload.name = ""; // Reset new table name
+      // Set to first available table if one exists, otherwise empty.
+      // User should ideally select one.
+      newPayload.table = context.tables.length > 0 ? context.tables[0].id : "";
+    }
+    onUpdateStep(newPayload);
+  };
+
+  // Determine current import option based on payload state
+  let currentImportOption = "Create new table"; // Default
+  if (step.table && step.table !== "") {
+    currentImportOption = "Import into existing table";
+  } else if (step.name && step.name !== "") {
+    currentImportOption = "Create new table";
+  }
+
+
+  return (
+    <div className="space-y-4">
+      {/* File Variable Select */}
+      <div className="space-y-2">
+        <Label htmlFor="importFile">File</Label>
+        <Select
+          value={step.file}
+          onValueChange={(value) =>
+            onUpdateStep({
+              ...step,
+              file: value,
+            })
+          }
+        >
+          <SelectTrigger id="importFile">
+            <SelectValue placeholder="Select file variable" />
+          </SelectTrigger>
+          <SelectContent>
+            {allUserInputVariables // Use dedicated prop for UserInput variables
+              .filter((v) => v.type === "file")
+              .map((v, idx) => (
+                <SelectItem key={idx} value={v.path}>
+                  {v.display}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-primary/80">
+          You can select any file-type variable defined in the UserInput step here.
+        </p>
+      </div>
+
+      {/* Import Option Select */}
+      <div className="space-y-2">
+        <Label htmlFor="importOption">Import Option</Label>
+        <Select
+          value={currentImportOption}
+          onValueChange={handleImportOptionChange}
+        >
+          <SelectTrigger id="importOption">
+            <SelectValue placeholder="Select import option" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Create new table">Create new table</SelectItem>
+            <SelectItem value="Import into existing table">
+              Import into existing table
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Conditional Fields for "Create new table" */}
+      {currentImportOption === "Create new table" && (
+        <div className="space-y-2">
+          <Label htmlFor="newTableName">New Table Name</Label>
+          <MentionInput
+            id="newTableName"
+            variables={context.variables} // Current step context variables for @-mentions
+            value={step.name ?? ""}
+            onChange={(e) =>
+              onUpdateStep({
+                ...step,
+                name: e.target.value,
+                table: "", // Ensure table is empty for "create new"
+              })
+            }
+            placeholder="Enter new table name or use @ for variables"
+          />
+        </div>
+      )}
+
+      {/* Conditional Fields for "Import into existing table" */}
+      {currentImportOption === "Import into existing table" && (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="existingTableName">Select Table</Label>
+            <Select
+              value={step.table ?? ""}
+              onValueChange={(value) =>
+                onUpdateStep({
+                  ...step,
+                  table: value,
+                  name: "", // Ensure name is empty for "import existing"
+                })
+              }
+            >
+              <SelectTrigger id="existingTableName">
+                <SelectValue placeholder="Select existing table" />
+              </SelectTrigger>
+              <SelectContent>
+                {context.tables.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center space-x-2 mt-2">
+            <Checkbox
+              id="truncateTable"
+              checked={step.truncate}
+              onCheckedChange={(checked) =>
+                onUpdateStep({
+                  ...step,
+                  truncate: !!checked,
+                })
+              }
+            />
+            <Label htmlFor="truncateTable" className="cursor-pointer">
+              Truncate table before import
+            </Label>
+          </div>
+        </>
+      )}
+
+      {/* Prompt */}
+      <div className="space-y-2">
+        <Label htmlFor="importPrompt">Prompt (Import Image)</Label>
+        <MentionInput
+          id="importPrompt"
+          className="mt-2"
+          textarea={true}
+          rows={3}
+          placeholder="Used only when importing images, as AI is required to extract data from them."
+          value={step.prompt}
+          variables={context.variables} // Current step context variables for @-mentions
+          onChange={(e) =>
+            onUpdateStep({
+              ...step,
+              prompt: e.target.value,
+            })
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/userInputStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/userInputStep.tsx
@@ -1,0 +1,189 @@
+import {
+  PlusCircle,
+  X,
+} from "lucide-react";
+
+import {
+  UserInputStepPayload,
+  WorkflowVariable,
+  WorkflowVariableType,
+} from "@/actions"; // Assuming these types are exported from actions
+import { StepContext } from "../builder"; // Import StepContext from builder
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { MentionInput, ContextVariable } from "@/components/ui/var-input"; // Ensure ContextVariable is imported if needed by MentionInput
+
+interface UserInputStepProps {
+  step: UserInputStepPayload;
+  context: StepContext; // Added context prop
+  onUpdateStep: (payload: UserInputStepPayload) => void;
+  onAddVariable: () => void;
+  onUpdateVariable: (
+    variableIndex: number,
+    updatedVariable: WorkflowVariable,
+  ) => void;
+  onRemoveVariable: (variableIndex: number) => void;
+}
+
+export function UserInputStep({
+  step,
+  context, // Destructure context
+  onUpdateStep,
+  onAddVariable,
+  onUpdateVariable,
+  onRemoveVariable,
+}: UserInputStepProps) {
+  // Helper to update a specific variable
+  const handleUpdateVariable = (
+    idx: number,
+    updatedVariable: WorkflowVariable,
+  ) => {
+    onUpdateVariable(idx, updatedVariable);
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs">
+        This step lets you add variables used in the workflow. When creating
+        other steps, you can type '@' to reference any variables defined here.
+        When the workflow starts, you’ll be prompted to input or select values
+        for all variables first.
+      </p>
+      <div className="flex justify-between items-center">
+        <Label>Variables</Label>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onAddVariable}
+          className="flex items-center gap-1"
+        >
+          <PlusCircle className="h-3.5 w-3.5" /> Add Variable
+        </Button>
+      </div>
+
+      {step.variables.length === 0 ? (
+        <div className="text-center p-4 border rounded-md text-muted-foreground">
+          No variables defined. Click "Add Variable" to create one.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {step.variables.map((variable, idx) => (
+            <div key={idx} className="p-3 border rounded-md space-y-3">
+              <div className="flex justify-between items-center">
+                <h4 className="font-medium">Variable {idx + 1}</h4>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onRemoveVariable(idx)}
+                >
+                  <X className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`var-name-${idx}`}>Name</Label>
+                <Input
+                  id={`var-name-${idx}`}
+                  value={variable.name}
+                  onChange={(e) => {
+                    const newName = e.target.value;
+                    const isValid = /^[a-zA-Z0-9]*$/.test(newName);
+                    if (isValid) {
+                      handleUpdateVariable(idx, {
+                        ...variable,
+                        name: newName,
+                      });
+                    }
+                    // If not isValid and not empty, the name is not updated.
+                  }}
+                  placeholder="e.g. tableName"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`var-type-${idx}`}>Type</Label>
+                <Select
+                  value={variable.type}
+                  onValueChange={(value: WorkflowVariableType) =>
+                    handleUpdateVariable(idx, {
+                      ...variable,
+                      type: value,
+                    })
+                  }
+                >
+                  <SelectTrigger id={`var-type-${idx}`}>
+                    <SelectValue placeholder="Select type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="string">String</SelectItem>
+                    <SelectItem value="integer">Integer</SelectItem>
+                    <SelectItem value="number">Number</SelectItem>
+                    <SelectItem value="file">File</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {variable.type !== "file" && (
+                <div className="space-y-2">
+                  <Label htmlFor={`var-default-${idx}`}>Default Value</Label>
+                  <MentionInput
+                    id={`var-default-${idx}`}
+                    variables={context.variables} // Pass context variables
+                    value={variable.default_value}
+                    onChange={(v) =>
+                      handleUpdateVariable(idx, {
+                        ...variable,
+                        default_value: v.target.value,
+                      })
+                    }
+                    placeholder={
+                      variable.type === "string"
+                        ? 'e.g. "users"'
+                        : variable.type === "number"
+                          ? "e.g. 3.14"
+                          : variable.type === "integer"
+                            ? "e.g. 20"
+                            : 'e.g. {"key": "value"}'
+                    }
+                  />
+                </div>
+              )}
+
+              {variable.type !== "file" && (
+                <div className="space-y-2">
+                  <Label htmlFor={`var-options-${idx}`}>
+                    Options (optional, one per line)
+                  </Label>
+                  <Textarea // Textarea does not use MentionInput's variable suggestions
+                    id={`var-options-${idx}`}
+                    defaultValue={variable.options.join("\n")}
+                    onChange={(e) => {
+                      handleUpdateVariable(idx, {
+                        ...variable,
+                        options: e.target.value
+                          .split("\n")
+                          .filter((opt) => opt.trim() !== ""),
+                      });
+                    }}
+                    className="w-full min-h-[100px] p-2 border rounded-md"
+                    placeholder="Enter options, one per line, will select one option when workflow start instead input value manually."
+                  />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/dialog/workflow/steps/userInputStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/userInputStep.tsx
@@ -21,12 +21,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { MentionInput, ContextVariable } from "@/components/ui/var-input"; // Ensure ContextVariable is imported if needed by MentionInput
+import { MentionInput } from "@/components/ui/var-input"; // Removed ContextVariable
 
 interface UserInputStepProps {
   step: UserInputStepPayload;
   context: StepContext; // Added context prop
-  onUpdateStep: (payload: UserInputStepPayload) => void;
+  // onUpdateStep: (payload: UserInputStepPayload) => void; // Removed unused prop
   onAddVariable: () => void;
   onUpdateVariable: (
     variableIndex: number,
@@ -38,7 +38,7 @@ interface UserInputStepProps {
 export function UserInputStep({
   step,
   context, // Destructure context
-  onUpdateStep,
+  // onUpdateStep, // Removed unused prop from destructuring
   onAddVariable,
   onUpdateVariable,
   onRemoveVariable,

--- a/ui/src/components/dialog/workflow/steps/userInputStep.tsx
+++ b/ui/src/components/dialog/workflow/steps/userInputStep.tsx
@@ -1,32 +1,28 @@
-import {
-  PlusCircle,
-  X,
-} from "lucide-react";
+import { PlusCircle, X } from "lucide-react";
 
 import {
-  UserInputStepPayload,
-  WorkflowVariable,
-  WorkflowVariableType,
-} from "@/actions"; // Assuming these types are exported from actions
-import { StepContext } from "../builder"; // Import StepContext from builder
+    UserInputStepPayload,
+    WorkflowVariable,
+    WorkflowVariableType,
+} from "@/actions";
+import { StepContext } from "../builder";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { MentionInput } from "@/components/ui/var-input"; // Removed ContextVariable
+import { MentionInput } from "@/components/ui/var-input";
 
 interface UserInputStepProps {
   step: UserInputStepPayload;
-  context: StepContext; // Added context prop
-  // onUpdateStep: (payload: UserInputStepPayload) => void; // Removed unused prop
+  context: StepContext;
   onAddVariable: () => void;
   onUpdateVariable: (
     variableIndex: number,
@@ -37,8 +33,7 @@ interface UserInputStepProps {
 
 export function UserInputStep({
   step,
-  context, // Destructure context
-  // onUpdateStep, // Removed unused prop from destructuring
+  context,
   onAddVariable,
   onUpdateVariable,
   onRemoveVariable,
@@ -138,7 +133,7 @@ export function UserInputStep({
                   <Label htmlFor={`var-default-${idx}`}>Default Value</Label>
                   <MentionInput
                     id={`var-default-${idx}`}
-                    variables={context.variables} // Pass context variables
+                    variables={context.variables}
                     value={variable.default_value}
                     onChange={(v) =>
                       handleUpdateVariable(idx, {
@@ -164,7 +159,7 @@ export function UserInputStep({
                   <Label htmlFor={`var-options-${idx}`}>
                     Options (optional, one per line)
                   </Label>
-                  <Textarea // Textarea does not use MentionInput's variable suggestions
+                  <Textarea
                     id={`var-options-${idx}`}
                     defaultValue={variable.options.join("\n")}
                     onChange={(e) => {


### PR DESCRIPTION
This commit completes the refactoring of all workflow step UI components from `builder.tsx` into individual files under the `steps/` directory. It also introduces alphanumeric validation for UserInput variable names.

Key changes:
- Extracted `ExportTableStep` UI into `steps/exportTableStep.tsx`.
- Updated `builder.test.tsx` to align with all refactored components. All original tests pass.
- Implemented alphanumeric-only validation for variable names within the `UserInputStep` component (`steps/userInputStep.tsx`). Non-alphanumeric characters are prevented from being saved in the variable name.
- Added a new test suite to `builder.test.tsx` with 7 test cases specifically for the UserInput variable name validation, covering various valid and invalid input scenarios. All new tests pass.

All 18 tests in `builder.test.tsx` are passing. This addresses the issue requirements for refactoring `workflow/builder.tsx` and adding variable name validation.